### PR TITLE
Add Initial Software Development Handbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vscode
 site/
+node_modules/
+package.json
+package-lock.json

--- a/doc/.nav.yml
+++ b/doc/.nav.yml
@@ -1,233 +1,183 @@
-software-standards/append_unmatched: true
-flatten_single_child_sections: true
 nav:
-  - Overview: index.md
-  - Handbook fundamentals:
-    - Development tools: handbook-fundamentals/development-tools.md
-    - Development principles: handbook-fundamentals/development-principles.md
-    - Testing: handbook-fundamentals/testing.md
-    - Security: handbook-fundamentals/security.md
-    - User interface and accessibility standards: handbook-fundamentals/ui-accessibility.md
-    - Writing and maintaining documentation: handbook-fundamentals/documentation.md
-
-  - Requesting a software subscription:
-    - Choosing the subscriptions you need: how-to-request-software-subscriptions/identify-subscription.md
-    - How to request a subscription: how-to-request-software-subscriptions/request-subscription.md
-    - How to cancel a subscription: how-to-request-software-subscriptions/cancelling-subscription.md
-    - Managing your subscriptions: how-to-request-software-subscriptions/managing-subscriptions.md    
-
-  - Agile delivery using scrum:
-    - Scrum: agile-delivery/scrum.md
-    - Cross-functional teams: agile-delivery/cross-functional-teams.md
-    - Agile Practices for requirements gathering: agile-delivery/agile-practices-requirements.md
-    - Planning your work in Azure DevOps: agile-delivery/agile-planning-azure-devops.md
-
-  - Using source control:
-    - Using our source control tools: using-source-control/use-source-control.md
-    - What to include in source control: using-source-control/include-in-source-control.md
-    - Use Git: using-source-control/6.3-use-git.md
-    - Establish a clear repo structure: using-source-control/repo-structure.md
-    - Commit changes early and often: using-source-control/commit-changes.md
-    - Write clear commit messages: using-source-control/commit-messages.md
-    - Review your code: using-source-control/review-code.md
-    - Follow a branching strategy: using-source-control/branching-strategy.md
-    - Adopt trunk-based development and continuous integration: using-source-control/trunk-based-development.md
-    - Implement a versioning strategy: using-source-control/versioning-strategy.md
-    - Keeping your repo tidy: using-source-control/keep-repo-organised.md
-    - Always deploy from source control: using-source-control/deploy-from-source-control.md
-    - Choosing and setting up a Git client: using-source-control/configure-git-clients.md
-
-  - How to organise your software solution:
-    - Organise your solution using our conventions: how-to-organise-your-software-solution/6.1-organise-solution.md
-    - Use physical folders: how-to-organise-your-software-solution/use-physical-folders.md
-    - Add a root folder for your solution: how-to-organise-your-software-solution/create-root-folder.md
-    - Add a README file: how-to-organise-your-software-solution/readme.md
-    - Add a .editorconfig file: how-to-organise-your-software-solution/editorconfig.md
-    - Add a source folder: how-to-organise-your-software-solution/create-source-folder.md
-    - Add sub-folders for dependency layers: how-to-organise-your-software-solution/subfolders-dependency-layers.md
-    - Use sub-folders within Visual Studio projects: how-to-organise-your-software-solution/subfolders-vs-projects.md
-    - Use existing conventions for project types: how-to-organise-your-software-solution/existing-project-conventions.md
-    - Add a specification folder: how-to-organise-your-software-solution/create-specs-folder.md
-    - Add a test folder: how-to-organise-your-software-solution/test-folder.md
-    - Add a documents folder: how-to-organise-your-software-solution/documents-folder.md
-    - Add a build folder: how-to-organise-your-software-solution/build-folder.md
-    - Add a scripts folder: how-to-organise-your-software-solution/scripts-folder.md
-    - Add a deploy folder: how-to-organise-your-software-solution/deploy-folder.md
-    - Add an examples folder: how-to-organise-your-software-solution/examples-folder.md
-
-  - General coding standards:
+  - Home: index.md
+  - Software Development Handbook:
+    - Introduction: software-development-handbook/introduction.md
+    - Development tools: software-development-handbook/development-tools.md
+    - Development principles: software-development-handbook/development-principles.md
+    - Agile delivery using Scrum: software-development-handbook/agile-delivery-using-scrum.md
+    - Testing: software-development-handbook/testing.md
+    - Security: software-development-handbook/security.md
+    - User interface and accessibility standards: software-development-handbook/user-interface-and-accessibility-standards.md
+    - Documentation: software-development-handbook/documentation.md
+    - Exceptions: software-development-handbook/exceptions.md
+    - Essential good practice checklists: software-development-handbook/essential-good-practice-checklists.md
+  - Using Source Control:
+    - Introduction: using-source-control/introduction.md
+    - Use our source control systems: using-source-control/use-our-source-control-systems.md
+    - What to include in source control: using-source-control/what-to-include-in-source-control.md
+    - Use Git: using-source-control/use-git.md
+    - Establish a clear repo structure: using-source-control/establish-a-clear-repo-structure.md
+    - Commit changes early and often: using-source-control/commit-changes-early-and-often.md
+    - Write clear commit messages: using-source-control/write-clear-commit-messages.md
+    - Review your code: using-source-control/review-your-code.md
+    - Follow a branching strategy: using-source-control/follow-a-branching-strategy.md
+    - Adopt trunk based development and continuous integration: using-source-control/adopt-trunk-based-development-and-continuous-integration.md
+    - Implement a versioning strategy: using-source-control/implement-a-versioning-strategy.md
+    - Keep your repo organised: using-source-control/keep-your-repo-organised.md
+    - Always deploy from source control: using-source-control/always-deploy-from-source-control.md
+    - Select and configure Git clients: using-source-control/select-and-configure-git-clients.md
+    - Exceptions: using-source-control/exceptions.md
+    - Essential good practice checklist: using-source-control/essential-good-practice-checklist.md
+  - Organising Your Solution:
+    - Introduction: organising-your-solution/introduction.md
+    - Organise your solution to accord with our conventions: organising-your-solution/organise-your-solution-to-accord-with-our-conventions.md
+    - Use physical folders: organising-your-solution/use-physical-folders.md
+    - Create a root folder for your solution: organising-your-solution/create-a-root-folder-for-your-solution.md
+    - Provide a readme file: organising-your-solution/provide-a-readme-file.md
+    - Create a editorconfig file: organising-your-solution/create-a-editorconfig-file.md
+    - Create a source folder: organising-your-solution/create-a-source-folder.md
+    - Use additional sub folders for dependency layers: organising-your-solution/use-additional-sub-folders-for-dependency-layers.md
+    - Use sub folders within visual studio projects: organising-your-solution/use-sub-folders-within-visual-studio-projects.md
+    - Use existing conventions for project types: organising-your-solution/use-existing-conventions-for-project-types.md
+    - Create a specification folder: organising-your-solution/create-a-specification-folder.md
+    - Provide a test folder: organising-your-solution/provide-a-test-folder.md
+    - Provide a documents folder: organising-your-solution/provide-a-documents-folder.md
+    - Provide a build folder: organising-your-solution/provide-a-build-folder.md
+    - Provide a scripts folder: organising-your-solution/provide-a-scripts-folder.md
+    - Provide a deploy folder: organising-your-solution/provide-a-deploy-folder.md
+    - Provide an examples folder: organising-your-solution/provide-an-examples-folder.md
+    - Exceptions prove the rule: organising-your-solution/exceptions-prove-the-rule.md
+    - Good practice checklists: organising-your-solution/good-practice-checklists.md
+  - General Coding Standards:
+    - Introduction: general-coding-standards/introduction.md
     - Write clean code: general-coding-standards/write-clean-code.md
-    - Follow SOLID principles: general-coding-standards/solid-principles.md
-    - Follow Microsoft’s coding conventions: 
-      - Naming: general-coding-standards/microsoft-naming.md
-      - Layout: general-coding-standards/microsoft-layout.md
-      - Comments: general-coding-standards/microsoft-comments.md
-      - Variable and parameter names: general-coding-standards/microsoft-variable-names.md
-      - Conditional statements: general-coding-standards/microsoft-conditional-statements.md
-      - Exception handling: general-coding-standards/microsoft-exception-handling.md
-    - Check and analyse your code:
-      - Create a plan: general-coding-standards/code-analysis/create-a-plan.md
-      - Calculate code metrics: general-coding-standards/code-analysis/calculate-metrics.md
-      - Calculate cyccode coverage: general-coding-standards/code-analysis/calculate-coverage.md
-      - Check for style and quality: general-coding-standards/code-analysis/check-style-quality.md
-      - Use code analysis tools: general-coding-standards/code-analysis/tools.md
-      - Configure code analysis rules: general-coding-standards/code-analysis/configure-rules.md
-      - Configure CI Pipelines: general-coding-standards/code-analysis/configure-ci-pipelines.md
-      - Check 3rd party packages: general-coding-standards/code-analysis/check-3rd-party.md
-      - Publish and review metrics: general-coding-standards/code-analysis/publish-review-metrics.md
-      - Quick recap: general-coding-standards/code-analysis/recap.md     
-     
-    - Examples:
-      - Unnecessary using statements: general-coding-standards/examples/unnecessary-using-statements.md
-      - Do not catch generic exceptions: general-coding-standards/examples/do-not-catch-generic-exception.md
-      - Dispose of objects properly: general-coding-standards/examples/dispose-objects-properly.md
-      - Use the null conditional operator: general-coding-standards/examples/use-null-conditional.md
-      - Make methods async: general-coding-standards/examples/make-methods-async.md
-
-  - T-SQL coding standards:
-    - Don't use T-SQL to execute business logic: software-standards/tsql-coding-standards/avoid-business-logic.md
-    - Using an ORM (Object Relational Mapper): software-standards/tsql-coding-standards/orm-rules.md
-    - Good habits: software-standards/tsql-coding-standards/good-practice.md
-    - Follow our table design rules - schemas and indexes: software-standards/tsql-coding-standards/table-design-schemas-indexes.md
-    - Follow our table rules - columns and datatypes: software-standards/tsql-coding-standards/columns-datatypes.md
-    - Apply code analysis rules: software-standards/tsql-coding-standards/code-analysis.md
-    - Using transactions: software-standards/tsql-coding-standards/transactions.md
-    - Using TOP (N) and ORDER BY: software-standards/tsql-coding-standards/top-orderby.md
-    - XML and JSON: software-standards/tsql-coding-standards/xml-json.md
-    - Date and time: software-standards/tsql-coding-standards/date-time.md
-    - Aliases: software-standards/tsql-coding-standards/aliases.md
-    - Views: software-standards/tsql-coding-standards/views.md
-    - Stored procedures: software-standards/tsql-coding-standards/stored-procedures.md
-    - Handling exceptions: software-standards/tsql-coding-standards/handling-exceptions.md
-    - Using User Defined Functions (UDF): software-standards/tsql-coding-standards/udfs.md
-    - Using Triggers: software-standards/tsql-coding-standards/triggers.md
-    - Permissions: software-standards/tsql-coding-standards/permissions.md
-    - Using SQL Server Agent: software-standards/tsql-coding-standards/sql-server-agent.md
-    - Follow our naming rules (see Table Design Rules too): software-standards/tsql-coding-standards/naming-rules.md
-    - Follow our code layout rules: software-standards/tsql-coding-standards/layout.md
-    - Commenting your code: software-standards/tsql-coding-standards/comments.md    
-  
-  - RESTful API design and build standards:
-    - API design:
-      - FHIR (Fast Healthcare Interoperability Standards): api/design/fhir.md
-      - Data classification: api/design/data-classification.md
-      - OpenAPI specification: api/design/openapi.md
-      - URL structure: api/design/url-structure.md
-      - How to retrieve related data: api/design/retrieving-related-data.md
-      - HTTP implementation: api/design/http.md
-      - Payload rules: api/design/payload-rules.md
-      - How to structure JSON responses: api/design/json-response.md
-      - Paging: api/design/paging.md
-      - Filtering: api/design/filtering.md
-      - Sorting: api/design/sorting.md
-      - handling compound collection operations: api/design/compound-operations.md
-      - Naming: api/design/naming.md
-      - Error reporting: api/design/error-reporting.md
-      - Performance and response times: api/design/performance.md
-      - Managing concurrency: api/design/concurrency.md
-      - Handling transient faults: api/design/transient-faults.md
-
-    - API security:
-      - API gateway pattern: api/security/api-gateway-pattern.md
-      - OWASP Top 10: api/security/owasp-top-10.md
-      - Managing secrets and certificates: api/security/secrets-and-certificates.md
-      - Encryption: api/security/encryption.md
-      - Security headers: api/security/security-headers.md
-      - HTTP message caching: api/security/http-caching.md
-      - Authentication and authorisation: api/security/auth.md
-
-    - API management:
-      - Generating an API proxy: api/management/generating-proxy.md
-      - Ping checks and service status: api/management/ping-status.md
-      - API lifecycle: api/management/lifecycle.md
-      - Deploying your API: api/management/deployment.md
-      - Versioning your API: api/management/versioning.md
-      - Cataloguing you API: api/management/cataloguing.md
-      - Audit, trace and monitoring your APIs: api/management/auditing-monitoring.md
-      - Rate limiting and throttling: api/management/rate-limiting.md
-
-    - API testing:
-      - Shift left: api/testing/shift-left.md
-      - Automate as much as you can: api/testing/automation.md
-      - Validate the OpenAPI specification: api/testing/validate-openapi.md
-      - Unit tests: api/testing/unit-tests.md
-      - Functional tests: api/testing/functional-tests.md
-      - Security tests: api/testing/security-tests.md
-      - Performance tests: api/testing/performance-tests.md
-      - Usability tests: api/testing/usability-tests.md
-      - Keep tests organised: api/testing/organise-tests.md
-      - Test summary report: api/testing/test-summary.md
-      - Test environment: api/testing/test-environment.md
-
-    - API tooling:
-      - Recommended tools: api/tooling/recommended-tools.md
-
-    - API docs:
-      - Writing style: api/documentation/writing-style.md
-      - OpenAPI specification: api/documentation/openapi-specification.md
-      - Document structure: api/documentation/structure.md
-      - Developer portal: api/documentation/developer-portal.md
-      - Software development kits (SDKs): api/documentation/sdks.md  
-
-    - API classifications:
-      - API type: api/classifications/api-type.md
-      - Data type: api/classifications/data-type.md
-      - Network routing type: api/classifications/network-routing.md
-      - Client type: api/classifications/client-type.md
-      - Client authentication level: api/classifications/client-authentication.md
-      - Service level: api/classifications/service-level.md
-      - Lifecycle status: api/classifications/lifecycle-status.md  
-
-  - Azure DevOps:
+    - Follow SOLID principles: general-coding-standards/follow-solid-principles.md
+    - Follow Microsoft's coding conventions: general-coding-standards/follow-microsofts-coding-conventions.md
+    - Analyse your code: general-coding-standards/analyse-your-code.md
+    - Exceptions: general-coding-standards/exceptions.md
+    - Examples: general-coding-standards/examples.md
+    - Essential good practice checklist: general-coding-standards/essential-good-practice-checklist.md
+  - T-SQL Coding Standard:
+    - Introduction: t-sql-coding-standard/introduction.md
+    - Avoid using t SQL to execute business logic: t-sql-coding-standard/avoid-using-t-sql-to-execute-business-logic.md
+    - Follow these rules when using an object relational mapper ORM: t-sql-coding-standard/follow-these-rules-when-using-an-object-relational-mapper-orm.md
+    - General good practice: t-sql-coding-standard/general-good-practice.md
+    - Follow out table design rules schemes and indexes: t-sql-coding-standard/follow-out-table-design-rules-schemes-and-indexes.md
+    - Follow our table rules columns and datatypes: t-sql-coding-standard/follow-our-table-rules-columns-and-datatypes.md
+    - Apply code analysis rules: t-sql-coding-standard/apply-code-analysis-rules.md
+    - Working with transactions: t-sql-coding-standard/working-with-transactions.md
+    - Top N and Order By: t-sql-coding-standard/top-n-and-order-by.md
+    - XML and JSON: t-sql-coding-standard/xml-and-json.md
+    - Date and time: t-sql-coding-standard/date-and-time.md
+    - Aliases: t-sql-coding-standard/aliases.md
+    - Views: t-sql-coding-standard/views.md
+    - Stored procedures: t-sql-coding-standard/stored-procedures.md
+    - Handling exceptions: t-sql-coding-standard/handling-exceptions.md
+    - Working with user defined functions UDF: t-sql-coding-standard/working-with-user-defined-functions-udf.md
+    - Working with triggers: t-sql-coding-standard/working-with-triggers.md
+    - Permissions: t-sql-coding-standard/permissions.md
+    - Working with SQL server agent: t-sql-coding-standard/working-with-sql-server-agent.md
+    - Follow our naming rules see also table design rules: t-sql-coding-standard/follow-our-naming-rules-see-also-table-design-rules.md
+    - Follow our code layout rules: t-sql-coding-standard/follow-our-code-layout-rules.md
+    - Code comments: t-sql-coding-standard/code-comments.md
+    - Exceptions prove the rule: t-sql-coding-standard/exceptions-prove-the-rule.md
+    - Examples: t-sql-coding-standard/examples.md
+    - SQL prompt configuration: t-sql-coding-standard/sql-prompt-configuration.md
+    - Good practice checklists: t-sql-coding-standard/good-practice-checklists.md
+  - RESTful API Standards:
+    - Introduction: restful-api-standards/introduction.md
+    - General principles: restful-api-standards/general-principles.md
+    - Definitions: restful-api-standards/definitions.md
+    - FHIR Fast Healthcare Interoperability Standards: restful-api-standards/fhir-fast-healthcare-interoperability-standards.md
+    - Data classification: restful-api-standards/data-classification.md
+    - Open API specification: restful-api-standards/open-api-specification.md
+    - Url structure: restful-api-standards/url-structure.md
+    - Retrieving related data: restful-api-standards/retrieving-related-data.md
+    - HTTP implementation: restful-api-standards/http-implementation.md
+    - Payload rules: restful-api-standards/payload-rules.md
+    - JSON response payload structure: restful-api-standards/json-response-payload-structure.md
+    - Paging: restful-api-standards/paging.md
+    - Filtering: restful-api-standards/filtering.md
+    - Sorting: restful-api-standards/sorting.md
+    - Compound collection operations: restful-api-standards/compound-collection-operations.md
+    - Naming: restful-api-standards/naming.md
+    - Error reporting: restful-api-standards/error-reporting.md
+    - Performance and response times: restful-api-standards/performance-and-response-times.md
+    - Concurrency control: restful-api-standards/concurrency-control.md
+    - Handling transient faults: restful-api-standards/handling-transient-faults.md
+    - API gateway pattern: restful-api-standards/api-gateway-pattern.md
+    - OWASP top 10: restful-api-standards/owasp-top-10.md
+    - Secrets and certificate management: restful-api-standards/secrets-and-certificate-management.md
+    - Encryption: restful-api-standards/encryption.md
+    - Security headers: restful-api-standards/security-headers.md
+    - HTTP message caching: restful-api-standards/http-message-caching.md
+    - Authentication and authorisation: restful-api-standards/authentication-and-authorisation.md
+    - API management: restful-api-standards/api-management.md
+    - Testing: restful-api-standards/testing.md
+    - Tooling: restful-api-standards/tooling.md
+    - Documentation: restful-api-standards/documentation.md
+    - Appendix A classifications: restful-api-standards/appendix-a-classifications.md
+    - Essential good practice checklist: restful-api-standards/essential-good-practice-checklist.md
+  - Azure DevOps Handbook:
+    - Introduction: azure-devops-handbook/introduction.md
     - Azure DevOps basics: azure-devops-handbook/azure-devops-basics.md
     - Joining an existing project: azure-devops-handbook/joining-an-existing-project.md
     - Creating a new project: azure-devops-handbook/creating-a-new-project.md
-    - Adding ysers and teams: azure-devops-handbook/adding-users-and-teams.md
-    - Planning and tracking work with Azure Boards: azure-devops-handbook/planning-and-tracking-work.md
-    - Managing source code with Azure Repos: azure-devops-handbook/managing-source-code.md
-    - Automating builds and deployments with Azure Pipelines: azure-devops-handbook/automating-builds.md
-    - Configuring agents for Azure Pipelines: azure-devops-handbook/configuring-agents.md
-    - Sharing code with Azure Artifacts: azure-devops-handbook/sharing-code.md
-    - Defining and running test cases with Azure Test Plans: azure-devops-handbook/running-test-cases.md
-    - Using Wikis: azure-devops-handbook/using-wikis.md
-    - Creating and managing dashboards: azure-devops-handbook/managing-dashboards.md
+    - Adding users and Teams: azure-devops-handbook/adding-users-and-teams.md
+    - Planning and tracking work with Azure boards: azure-devops-handbook/planning-and-tracking-work-with-azure-boards.md
+    - Managing source code with Azure repos: azure-devops-handbook/managing-source-code-with-azure-repos.md
+    - Automating builds and deployments with Azure pipelines: azure-devops-handbook/automating-builds-and-deployments-with-azure-pipelines.md
+    - Configuring agents for Azure pipelines: azure-devops-handbook/configuring-agents-for-azure-pipelines.md
+    - Sharing code with Azure artifacts: azure-devops-handbook/sharing-code-with-azure-artifacts.md
+    - Defining and running test cases with Azure test plans: azure-devops-handbook/defining-and-running-test-cases-with-azure-test-plans.md
+    - Using wikis: azure-devops-handbook/using-wikis.md
+    - Creating and managing dashboards: azure-devops-handbook/creating-and-managing-dashboards.md
     - Managing user settings: azure-devops-handbook/managing-user-settings.md
-    - Project housekeeping tasks: azure-devops-handbook/project-housekeeping.md
-    - Securing your projects: azure-devops-handbook/securing-projects.md
+    - Project housekeeping tasks: azure-devops-handbook/project-housekeeping-tasks.md
+    - Securing your projects: azure-devops-handbook/securing-your-projects.md
     - Managing costs: azure-devops-handbook/managing-costs.md
-    - Support and troubleshooting: azure-devops-handbook/support-troubleshooting.md
-    - Enabling GitHub Advanced Security: azure-devops-handbook/github-advanced-security.md
-    - Connecting Defender for cloud devOps: azure-devops-handbook/connecting-defender.md
-    - Using Azure DevOps extensions: azure-devops-handbook/using-extensions.md
-    - Data privacy and availability: azure-devops-handbook/data-privacy.md
-    
-
-  - Writing a Test Summary report:
-    - When to create a Test Summary Report: test-summary-reports/when-to-create.md
-    - Characteristics of a good Test Summary Report: test-summary-reports/characteristics.md
-    - Cover page: test-summary-reports/cover-page.md
-    - Table of contents: test-summary-reports/table-of-contents.md
-    - Document location: test-summary-reports/document-location.md
-    - Relevant documents: test-summary-reports/relevant-documents.md
-    - Version control: test-summary-reports/version-control.md
-    - Reviews and approvals: test-summary-reports/reviews-and-approvals.md
-    - Summary of testing: test-summary-reports/summary-of-testing.md
-    - Test metrics: test-summary-reports/test-metrics.md
-    - Further metrics: test-summary-reports/further-metrics.md
-    - Filename: test-summary-reports/filename.md
-    - Layout and formatting: test-summary-reports/layout-formatting.md
-    - Example reports: test-summary-reports/example-reports.md
-
-  - Testing for lost updates:
-    - Overview: testing-lost-updates/index.md
-    - What’s a lost update: testing-lost-updates/whats-a-lost-update.md
-    - How do you test for lost updates: testing-lost-updates/how-to-test.md
-    - Follow a risk based approach: testing-lost-updates/risk-based-approach.md
+    - Support and troubleshooting: azure-devops-handbook/support-and-troubleshooting.md
+    - Enabling GitHub Advanced Security: azure-devops-handbook/enabling-github-advanced-security.md
+    - Connecting Defender for Cloud DevOps: azure-devops-handbook/connecting-defender-for-cloud-devops.md
+    - Using Azure DevOps extensions: azure-devops-handbook/using-azure-devops-extensions.md
+    - Data privacy and availability: azure-devops-handbook/data-privacy-and-availability.md
+    - Essential good practice checklist: azure-devops-handbook/essential-good-practice-checklist.md
+  - Software Subscriptions:
+    - Introduction: software-subscriptions/introduction.md
+    - What subscriptions are available: software-subscriptions/what-subscriptions-are-available.md
+    - Identify the subscription you need: software-subscriptions/identify-the-subscription-you-need.md
+    - Requesting a subscription: software-subscriptions/requesting-a-subscription.md
+    - Cancelling a subscription: software-subscriptions/cancelling-a-subscription.md
+    - Managing subscriptions: software-subscriptions/managing-subscriptions.md
+  - Test Summary Report:
+    - Introduction: test-summary-report/introduction.md
+    - When to create a test summary report: test-summary-report/when-to-create-a-test-summary-report.md
+    - Characteristics of a good test summary report: test-summary-report/characteristics-of-a-good-test-summary-report.md
+    - Cover page: test-summary-report/cover-page.md
+    - Table of contents: test-summary-report/table-of-contents.md
+    - Document location: test-summary-report/document-location.md
+    - Relevant documents: test-summary-report/relevant-documents.md
+    - Version control: test-summary-report/version-control.md
+    - Reviews and approvals: test-summary-report/reviews-and-approvals.md
+    - Summary of testing: test-summary-report/summary-of-testing.md
+    - Test metrics: test-summary-report/test-metrics.md
+    - Further metrics: test-summary-report/further-metrics.md
+    - Filename: test-summary-report/filename.md
+    - Layout and formatting: test-summary-report/layout-and-formatting.md
+    - Example reports: test-summary-report/example-reports.md
+    - Exceptions prove the rule: test-summary-report/exceptions-prove-the-rule.md
+  - Testing for Lost Updates:
+    - Introduction: testing-lost-updates/introduction.md
+    - Whats a lost update: testing-lost-updates/whats-a-lost-update.md
+    - How do you test for lost updates: testing-lost-updates/how-do-you-test-for-lost-updates.md
+    - Follow a risk based approach: testing-lost-updates/follow-a-risk-based-approach.md
     - Concurrency controls: testing-lost-updates/concurrency-controls.md
     - Locking: testing-lost-updates/locking.md
-    - No locking, but validation checks: testing-lost-updates/no-locking.md
-    - No concurrency controls: testing-lost-updates/no-concurrency.md
-    - Write and execute tests: testing-lost-updates/write-execute-tests.md
+    - Write and execute tests: testing-lost-updates/write-and-execute-tests.md
     - Example test scripts: testing-lost-updates/example-test-scripts.md
-    
-  - Checklists: checklists.md  
+    - Further reading: testing-lost-updates/further-reading.md
+  - Coding Standard Template:
+    - Introduction: coding-standard-template/introduction.md
+    - Use a brief heading to describe the standards: coding-standard-template/use-a-brief-heading-to-describe-the-standards.md
+    - Exceptions prove the rule: coding-standard-template/exceptions-prove-the-rule.md
+    - Good practice checklists: coding-standard-template/good-practice-checklists.md

--- a/doc/azure-devops-handbook/adding-users-and-teams.md
+++ b/doc/azure-devops-handbook/adding-users-and-teams.md
@@ -1,0 +1,42 @@
+# Adding users and Teams
+
+## Add users
+
+When adding users, you **MUST** grant only the minimum access level
+necessary. Use built-in [security groups](azure-devops-basics.md) for
+easier management, avoiding broad groups unless essential.
+
+!!! info "Further reading and information"
+    [Add users or groups to a team or project - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/add-users-team-project?view=azure-devops&tabs=preview-page)
+
+## Add additional Teams
+
+Each project has a default team, "*<Project Name\>* Team". You can add
+teams for specific areas or products, each with its own backlogs,
+sprints, and dashboards.
+
+!!! tip "Practical tips"
+    When creating a team, use a clear, descriptive name that reflects its focus (e.g. feature or product), Avoid generic terms like *"Developers".*
+
+!!! example "Examples of good practice"
+    **Phoenix Portal Team:** Front-end UI and integration with back-end APIs.
+
+    **Titan Mobile Team:** Mobile app and integration with back-end APIs.
+
+    **Atlas Immunisations API Team:** Backend Immunisation APIs.
+
+    **Helios Appointments Team**: Immunisations appointment scheduler microservice.
+
+    **Developers**
+
+!!! info "Further reading and information"
+    [Create or add a team - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/settings/add-teams?view=azure-devops&tabs=preview-page)
+
+## Configure area paths for Teams
+
+Create a new area path for each new Azure DevOps team. This keeps
+backlogs, boards, and queries specific to each team while allowing
+access to the shared backlog.
+
+!!! info "Further reading and information"
+    [Define area paths and assign to a team - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/settings/set-area-paths?view=azure-devops&tabs=browser)

--- a/doc/azure-devops-handbook/automating-builds-and-deployments-with-azure-pipelines.md
+++ b/doc/azure-devops-handbook/automating-builds-and-deployments-with-azure-pipelines.md
@@ -1,0 +1,94 @@
+# Automating builds and deployments with Azure pipelines
+
+You **SHOULD** use Azure Pipelines to automate build, test, and
+deployment processes, enabling Continuous Integration (CI) & Continuous
+Deployment (CD).
+
+## How do you organise your code?
+
+Follow *[How to Organise Your Software Solution](../organising-your-solution/introduction.md)* to maintain a
+clean, modular codebase and keep build and deployment scripts separate
+to reduce clutter.
+
+!!! tip "Practical tips"
+    Place pipeline YAML files in the build/scripts/ folder unless operational needs require a different location.
+
+!!! info "Further reading and information"
+    [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+
+## Core pipeline characteristics
+
+Follow [Microsoft's baseline architecture](https://learn.microsoft.com/en-gb/azure/devops/pipelines/architectures/devops-pipelines-baseline-architecture?view=azure-devops)
+to build repeatable, scalable Azure pipelines.
+
+Key considerations:
+
+- **Use YAML:** Prefer YAML pipelines for version control and sharing
+    configurations.
+
+- **Modular Design:** Create reusable templates & separate stages
+    (e.g. Build, Test, Deploy).
+
+- **Gradual Deployment:** Use progressive strategies (e.g. DevTest \>
+    UAT \> Prod).
+
+- **Integrate Security:** Include code analysis and vulnerability
+    scanning.
+
+- **Automated Testing:** Run automated tests with coverage reporting.
+
+- **Approvals**
+
+  - Pre-approval checks are **RECOMMENDED** for DevTest and UAT.
+
+  - Pre-approval checks **SHOULD** be in place before deploying to
+        Prod.
+
+- **Secure Secrets:** Use tools like Azure Key Vault to manage
+    secrets.
+
+- **Store Artifacts:** Retain build outputs for traceability.
+
+!!! tip "Practical tips"
+    Not all pipelines need every feature; apply those relevant to the pipeline's purpose.
+
+!!! info "Further reading and information"
+    [Azure Pipelines baseline architecture - Azure Pipelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/pipelines/architectures/devops-pipelines-baseline-architecture?view=azure-devops)
+
+    [Azure Pipelines documentation - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/pipelines/?view=azure-devops)
+
+## Prefer YAML over classic release pipelines
+
+Use YAML pipelines for improved version control, tracking, and auditing.
+
+While Classic Release pipelines can still be useful, YAML deployment
+jobs and Azure DevOps Environments are preferred for greater flexibility
+and scalability.
+
+Deployment groups may suit VM-based deployments but offer less control
+than YAML.
+
+## Naming conventions
+
+| **COMPONENT** | **NAMING CONVENTION** | **example** |
+| --- | --- | --- |
+| **pipeline** | <repository-name\>-<purpose\> (*purpose* = pr, ci, cd) | wis-api-pr welshpas-web-ci wcp -integration-services-cd |
+| **Pipeline Run** **(YAML name)** | \$ (Build.DefinitionName)\_ \$(SourceBranchName)\_ \$( Date:yyyyMMdd).\$(Rev:r) | welshpas-web-ci_main_20241203.1 |
+| **STAGE** | PascalCase, descriptive | Build, Test, DeployToProd |
+| **JOB** | PascalCase, descriptive | RunUnitTests, BuildDockerImage, DeployToProd |
+| **ENVIRONMENT** | <DevTest \| UAT \| PROD\> | DevTest, UAT, Prod |
+| **DEPLOYMENT** | DeployTo<Environment\> | DeployToDevTest, DeployToUAT, DeployToProd |
+| **VARIABLES** | PascalCase, descriptive | KeyVaultName |
+| **LIBRARY VARIABLES** | *Lib-<name\>* | Lib-ApiEndpoint |
+| **LIBRARY VARIABLES** **(LINKED TO KEY VAULT)** | *Kv-<name\>* | Kv-APIKey |
+
+!!! tip "Practical tips"
+    Use clear, descriptive displayName values to clarify purpose and enhance readability.
+
+    When building Nuget packages, using version numbers as pipeline run names is **RECOMMENDED**. 
+    See [Versioning conventions](sharing-code-with-azure-artifacts.md).
+
+## Link work items to builds
+
+**Automatically link work items included:** In Pipeline settings choose
+to connect work items with each build result.

--- a/doc/azure-devops-handbook/azure-devops-basics.md
+++ b/doc/azure-devops-handbook/azure-devops-basics.md
@@ -1,0 +1,34 @@
+# Azure DevOps basics
+
+## Core concepts and terminology
+
+| **Concept** | **Description** |
+| --- | --- |
+| **Organisation** | The top-level container, representing a server instance. Each organisation has its own configuration and owner. |
+| **Project** | A unit within an organisation that includes repositories, planning tools, and Continuous Integration (CI) & Continuous Delivery (CD) capabilities. |
+| **Team** | A subset of a project, enabling smaller groups to work on specific features or components. |
+| **Access Levels** | These define the available features to a user, There are three access levels: *Stakeholder*, *Basic* and *Basic + Test Plans*. |
+| **Access Permissions** | These control specific actions (e.g. read, write, delete) on resources within projects. |
+| **Security Groups** | These group users to manage permissions and apply policies consistently. |
+
+## Key features
+
+| **Concept** | **FUNCTION** |
+| --- | --- |
+| **Boards** | Track and prioritise work using tasks, sprints, and backlogs. |
+| **Repos** | Manage and store source code in Git repositories. |
+| **Pipelines** | Automate code build, test and deployment processes. |
+| **Artifacts** | Store build outputs, like compiled binaries and packages. |
+| **Test Plans** | Define and execute test cases to ensure code quality. |
+
+## Common security groups
+
+Azure DevOps organises user permissions into roles. Use the table below
+to determine which role best suits your needs.
+
+| **Role** | **Description** |
+| --- | --- |
+| **Contributor** | Daily users of Azure DevOps. Key tasks: - Cloning, pushing, and pulling code in repositories. - Creating and managing work items, tasks, and bugs. - Participating in sprints and board activities. - Triggering and monitoring CI/CD pipelines. |
+| **Project Administrator** | Administers specific projects. Key responsibilities: - Assigning user permissions and configuring project settings. - Setting up repositories, boards, and sprint iterations. - Creating and maintaining CI/CD pipelines and housekeeping tasks. |
+| **Project Collection Administrator** | Oversees multiple projects. Key tasks: - Managing shared resources like package feeds and deployment agents. - Setting up pipelines that span projects. |
+| **Organisation Owner** | Global administrator for the organisation. Responsibilities include: - Creating projects and configuring global policies. - Managing billing, subscriptions and user accounts. |

--- a/doc/azure-devops-handbook/configuring-agents-for-azure-pipelines.md
+++ b/doc/azure-devops-handbook/configuring-agents-for-azure-pipelines.md
@@ -1,0 +1,85 @@
+# Configuring agents for Azure pipelines
+
+Agents execute tasks in an Azure Pipeline and are available in two
+types:
+
+- **Self-Hosted Agents**: Managed on your infrastructure.
+
+- **Microsoft-Hosted Agents**: Fully managed by Microsoft and
+    available on demand.
+
+## Choose an agent type
+
+Choosing the right agent type depends on your needs -- see below.
+
+| **COMPONENT** | **SELF-HOSTED** | **MICROSOFT-HOSTED** |
+| --- | --- | --- |
+| **COST** | Pay for VMs; build minutes/parallel jobs covered by Visual Studio Enterprise subscriptions. | Pay per minute beyond free-tier usage. |
+| **MANAGEMENT** | Manual setup and maintenance required. | Fully managed; no setup needed. |
+| **FLEXIBILITY** | Full control over tools and network configuration. | Preconfigured environments; limited customisation. |
+| **SCALABILITY** | Limited by VM capacity and no. of available Visual Studio Enterprise subscriptions. | Scales on demand; no infrastructure limits. |
+| **AVAILABILITY** | Restricted to DevTest VM uptime: Mon--Fri: 7 PM--7 AM. Sat & Sun: Unavailable. | Available without downtime. |
+
+## Our recommendation
+
+Use **Self-Hosted Agents** for cost-effective scaling with multiple
+parallel jobs under our Visual Studio agreement.
+
+Use **Microsoft-Hosted Agents** for occasional tasks or to avoid
+management overheads and VM costs.
+
+!!! info "Further reading and information"
+    [Azure Pipelines Agents - Azure Pipelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/pipelines/agents/agents?view=azure-devops&tabs=yaml%2Cbrowser)
+
+## Setting up a self-hosted agent
+
+To configure a self-hosted agent:
+
+- Provision an Azure Virtual Machine.
+
+- Add the agent to an existing pool (create a new pool if needed).
+
+- Install and configure the agent software from Azure DevOps.
+
+- Run the agent as a service for automatic restarts.
+
+## Securing a self-hosted agent
+
+To ensure agent security:
+
+- Use separate pools for different projects to reduce risk.
+
+- Assign a dedicated pool for production deployments.
+
+- Restrict access to the agent folder to authorised personnel.
+
+- Clean temporary files in the agent's build folder regularly.
+
+- Keep the agent software updated.
+
+- Run the agent under a service account (e.g., Network Service or
+    Local Service).
+
+- Avoid using admin or high-privilege accounts.
+
+## Recommended naming conventions
+
+Use clear, descriptive names for agents and pools to improve
+readability.
+
+| **COMPONENT** | **NAMING CONVENTION** | **example** |
+| --- | --- | --- |
+| **AGENT** | <team or project name\>-<agent type\> | wis-api-self-hosted, welshpas-web-ms-hosted |
+| **AGENT POOL** | <team or project name\>-<purpose\> | wis-api-build, welshpas-web-deploy |
+
+!!! tip "Practical tips"
+    When using [GitHub Advanced Security](enabling-github-advanced-security.md) allow additional URLs for the self-hosted agent to access data for *Dependency Scanning*.
+
+!!! info "Further reading and information"
+    [Deploy an Azure Pipelines agent on Windows - Azure Pipelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/pipelines/agents/windows-agent?view=azure-devops)
+
+    [Enable TLS 1.2 on clients -- Configuration Manager \| Microsoft Learn](https://learn.microsoft.com/en-gb/mem/configmgr/core/plan-design/security/enable-tls-1-2-client)
+
+    [Allowed address lists and network connections - Azure DevOps \| Microsoft Le arn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/allow-list-ip-url?view=azure-devops&tabs=IP-V4)
+
+    [Configure GitHub Advanced Security for Azure DevOps -- Azure Repos \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/repos/security/configure-github-advanced-security-features?view=azure-devops&tabs=yaml)

--- a/doc/azure-devops-handbook/connecting-defender-for-cloud-devops.md
+++ b/doc/azure-devops-handbook/connecting-defender-for-cloud-devops.md
@@ -1,0 +1,30 @@
+# Connecting defender for cloud DevOps
+
+Connecting Azure DevOps to Microsoft Defender for Cloud helps identify
+and fix security issues. Check with your Organisation Owner and Cyber
+Security team about potential costs first.
+
+The following practices are **RECOMMENDED**:
+
+- **Connect to Defender for Cloud**: Organisation Owners **MAY** link
+      Azure DevOps to Defender for Cloud for security insights. This
+      will also install the *Defender for DevOps Container Mapping*
+      extension to protect containerized applications.
+
+- **Enable Pull Request Annotations**: Turn on annotations to
+      highlight security issues in pull requests, so they can be fixed
+      before merging.
+
+- **Review Alerts and Recommendations**: Regularly review Defender for
+    Cloud alerts and follow recommendations to reduce risks.
+
+!!! info "Further reading and information"
+    [Microsoft Defender for Cloud DevOps Security Benefits \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/defender-for-cloud/defender-for-devops-introduction)
+
+    [Connect Azure DevOps to Defender for Cloud \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/defender-for-cloud/quickstart-onboard-devops)
+
+    [Configure the Security DevOps Extension \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/defender-for-cloud/azure-devops-extension)
+
+    [Microsoft Security DevOps Extension for Azure DevOps \| GitHub](https://github.com/microsoft/security-devops-azdevops?tab=readme-ov-file)
+
+    [Enable Pull Request Annotations \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/defender-for-cloud/enable-pull-request-annotations)

--- a/doc/azure-devops-handbook/creating-a-new-project.md
+++ b/doc/azure-devops-handbook/creating-a-new-project.md
@@ -1,0 +1,51 @@
+# Creating a new project
+
+## Request a new project
+
+Sometimes you may need to create a new project. Do so by making a
+request to the Organisation Owner. When creating a new project the
+following project property settings are **RECOMMENDED**:
+
+| **PROPERTY** | **VALUE** |
+| --- | --- |
+| **project name:** | Use the project acronym for shorter URLs. Avoid spaces. |
+| **description:** | Provide a clear, searchable project description. |
+| **visibility:** | Private |
+| **version control:** | Git |
+| **work item process:** | Agile |
+
+!!! info "Further reading and information"
+    [Find or look up the organisation owner - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/look-up-organization-owner?view=azure-devops)
+
+## Assign project admins
+
+Every project **SHOULD** have **two** project administrators. A project
+administrator manages access, configures project settings and customises
+boards for teams and workflows.
+
+!!! tip "Practical tips"
+    **Project Collection Administrator**
+
+    Depending on your requirements, it might be more suitable to also assign *Project Collection Administrators*. Speak to the Organisation Owner for more help.
+
+!!! info "Further reading and information"
+    [Find a project administrator - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/look-up-project-administrators?view=azure-devops&tabs=preview-page)
+
+## Remove unused features
+
+The Project Administrator **SHOULD** disable any features or services
+that are not required.
+
+!!! info "Further reading and information"
+    [Turn a service on or off - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/settings/set-services?view=azure-devops)
+
+## Choose a project profile image
+
+Use a suitable DHCW sub brand logo If you intend to change the *Project
+Profile Image.*
+
+## Disable telemetry and data access
+
+You **SHOULD** disable [extensions](using-azure-devops-extensions.md) that
+send telemetry or access repositories automatically in project settings
+before using the project.

--- a/doc/azure-devops-handbook/creating-and-managing-dashboards.md
+++ b/doc/azure-devops-handbook/creating-and-managing-dashboards.md
@@ -1,0 +1,18 @@
+# Creating and managing dashboards
+
+Use dashboards to monitor key metrics like test results, build quality,
+code coverage and burn-down rates. The following layout is
+**RECOMMENDED**:
+
+- **Top row:** Display build metrics for quick visibility of build
+    status.
+
+- **Middle row:** Show test results and code quality metrics to track
+    code health.
+
+- **Bottom row**: Reserve for sprint and team performance metrics.
+
+> {IMAGE PLACEHOLDER}
+
+!!! info "Further reading and information"
+    [Understand dashboards, charts, reports, and widgets - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/report/dashboards/overview?view=azure-devops)

--- a/doc/azure-devops-handbook/data-privacy-and-availability.md
+++ b/doc/azure-devops-handbook/data-privacy-and-availability.md
@@ -1,0 +1,21 @@
+# Data privacy and availability
+
+Azure DevOps Services includes strong data protection, availability and
+features:
+
+- **Data Availability:** Continuous access through data redundancy,
+    even during failures.
+
+- **Service Availability:** High uptime with built-in availability
+    mechanisms.
+
+- **Service Security**: Protection against threats and
+    vulnerabilities.
+
+- **Data Privacy:** Compliance with privacy laws and best practices
+
+!!! info "Further reading and information"
+    [Data protection overview - Azure DevOps Services \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/data-protection?view=azure-devops)
+
+!!! tip "Practical tips"
+    YOU **MUST NOT** store Personal Identifiable information (PII) in Azure DevOps!

--- a/doc/azure-devops-handbook/defining-and-running-test-cases-with-azure-test-plans.md
+++ b/doc/azure-devops-handbook/defining-and-running-test-cases-with-azure-test-plans.md
@@ -1,0 +1,23 @@
+# Defining and running test cases with Azure test plans
+
+You **SHOULD** follow these practices when defining and running test
+cases in Azure DevOps:
+
+- Create test plans to organise and manage test cases.
+
+- Link test cases to work items for better tracking.
+
+- Automate testing to improve consistency and efficiency.
+
+- Use charts to visualise test results and include them in Test
+    Summary reports.
+
+- Regularly review and update test cases to maintain proper coverage.
+
+!!! tip "Practical tips"
+    A **Visual Studio Test Professional** or **Azure DevOps Basic + Test Plans** subscription is needed to use Azure Test Plans.
+
+!!! info "Further reading and information"
+    [What are Azure Test Plans? - Azure Test Plans \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/test/overview?view=azure-devops)
+
+    [Azure Test Plans documentation - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/test/?view=azure-devops)

--- a/doc/azure-devops-handbook/enabling-github-advanced-security.md
+++ b/doc/azure-devops-handbook/enabling-github-advanced-security.md
@@ -1,0 +1,34 @@
+# Enabling GitHub advanced security
+
+Enabling **GitHub Advanced Security** helps you find & fix security
+issues in your code but does incur extra costs. So, check with your line
+manager or Organisation Owner before enabling it.
+
+The following practices are **RECOMMENDED**:
+
+- **Block Secrets on Push:** Enable the "*Block secrets on push*"
+    setting to prevent accidental exposure of secrets in your code.
+
+- **Review and Resolve Flagged Secrets:** Address other secrets
+    flagged by Azure DevOps (even if not blocked). E.g. by moving them
+    to secure storage like Azure Key Vault.
+
+- **Conducting Dependency Scanning:** Add the Dependency Scanning task
+    to your Azure Pipelines to identify vulnerabilities in third-party
+    libraries.
+
+- **Code Scanning with CodeQL:** Add the CodeQL scanning task to your
+    pipelines to identify security vulnerabilities and code quality
+    issues.
+
+- **Microsoft Security DevOps Extension:** Install this to use static
+    analysis tools like *ESLint*, *Checkov*, and *Terrascan* to scan for
+    vulnerabilities in Azure Pipelines.
+
+!!! tip "Practical tips"
+    Security tools may flag valid code (false positives) or miss vulnerabilities (false negatives).
+
+!!! info "Further reading and information"
+    [Configure GitHub Advanced Security for Azure DevOps features - Azure Repos \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/repos/security/configure-github-advanced-security-features?view=azure-devops&tabs=yaml)
+
+    [Implementing GitHub Advanced Security for Azure DevOps (youtube.com)](https://www.youtube.com/watch?v=Rdlo33QYvXk)

--- a/doc/azure-devops-handbook/essential-good-practice-checklist.md
+++ b/doc/azure-devops-handbook/essential-good-practice-checklist.md
@@ -1,0 +1,24 @@
+# Essential good practice checklist
+
+| **No.** | **Checklist Item** |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 1 | You grant only the minimum access level necessary and follow the principle of lease privilege. | ☐ | [Add Users](adding-users-and-teams.md) & [Securing your projects](securing-your-projects.md) |  |
+| 2 | You do NOT store Personal Identifiable Information (PII) in Azure DevOps. | ☐ | [Data privacy and availability](data-privacy-and-availability.md) |  |
+| 3 | You do NOT store controlled document information in a wiki. | ☐ | [Using Wikis](using-wikis.md) |  |
+| 4 | You do NOT publish packages with pre-release tags to organisation feeds. |  | [Publishing to shared organisation feeds](sharing-code-with-azure-artifacts.md) |  |
+| 5 | Projects have at least two Project Administrators | ☐ | [Assign project admins](creating-a-new-project.md) |  |
+| 6 | You disable extensions that send telemetry or access repositories. | ☐ | [Disable telemetry and data access](creating-a-new-project.md#disable-telemetry-and-data-access) |  |
+| 7 | You remove unused features | ☐ | [Remove unused features](creating-a-new-project.md#remove-unused-features) |  |
+| 8 | You follow our conventions and naming standards | ☐ | All |  |
+| 9 | You tag releases and generate automatic release notes | ☐ | [Package naming conventions](sharing-code-with-azure-artifacts.md) |  |
+| 10 | You use Semantic Versioning (SemVer 2.0.0). | ☐ | [How do you version your code?](sharing-code-with-azure-artifacts.md#how-do-you-version-your-code) |  |
+| 11 | You follow a branching and release strategy | ☐ | [How do you branch and release?](managing-source-code-with-azure-repos.md) |  |
+| 12 | You link work items to git commits. | ☐ | [Configure repository settings for commit linking](managing-source-code-with-azure-repos.md) |  |
+| 13 | You use Azure Pipelines to automate build, test, & deployments | ☐ | [Automating builds and deployments](automating-builds-and-deployments-with-azure-pipelines.md) |  |
+| 14 | Deployment to production requires a pre-approval check. | ☐ | [Core pipeline characteristics](automating-builds-and-deployments-with-azure-pipelines.md) |  |
+| 15 | You share code using Azure Artifacts | ☐ | [Sharing code](sharing-code-with-azure-artifacts.md) |  |
+
+| **No.** | **Checklist Item** |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 16 | You use Azure Test Plans to store and manage manual tests | ☐ | [Defining and Running Test Cases](defining-and-running-test-cases-with-azure-test-plans.md) |  |
+| 17 | You control and manage costs | ☐ | [Managing costs](managing-costs.md) |  |

--- a/doc/azure-devops-handbook/introduction.md
+++ b/doc/azure-devops-handbook/introduction.md
@@ -1,0 +1,95 @@
+# Introduction
+
+## Purpose
+
+This opinionated guide explains how to use Azure DevOps to manage
+software projects. If you're new to Azure DevOps or DevOps in general,
+start by reading the Ebook -- 'What is DevOps?'
+
+!!! info "Further reading and information"
+    [What Is DevOps? - Azure DevOps Succinctly Ebook \| Syncfusion](https://www.syncfusion.com/succinctly-free-ebooks/azure-devops-succinctly/what-is-devops)
+
+And for in-depth training use:
+
+!!! info "Further reading and information"
+    [Get started with Azure DevOps learning path - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/paths/evolve-your-devops-practices/)
+
+    [Build applications with Azure DevOps learning path - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/paths/build-applications-with-azure-devops/)
+
+    [Deploy applications with Azure DevOps learning path - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/paths/deploy-applications-with-azure-devops/)
+
+    [Define and implement continuous integration - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/paths/az-400-define-implement-continuous-integration/?ns-enrollment-type=Collection&ns-enrollment-id=8x18srwn4p8y4g)
+
+    [AZ-400: Design and implement a dependency management strategy - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/paths/az-400-design-implement-dependency-management-strategy/?ns-enrollment-type=Collection&ns-enrollment-id=8x18srwn4p8y4g)
+
+    [AZ-400: Design and implement a release strategy - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/paths/az-400-design-implement-release-strategy/)
+
+    [AZ-400: Implement CI with Azure Pipelines and GitHub Actions - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/paths/az-400-implement-ci-azure-pipelines-github-actions/)
+
+    [How Microsoft develops with DevOps - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/devops/develop/how-microsoft-develops-devops)
+
+## Scope
+
+### In-scope
+
+- Good practices for using Azure DevOps core and advanced features.
+
+- Recommended conventions and naming standards.
+
+- [Good practice](../restful-api-standards/essential-good-practice-checklist.md) checklist.
+
+### Out-of-scope
+
+- Creating and configuring a new Azure DevOps organisation.
+
+- Adding external users to Azure DevOps projects and teams.
+
+- Integrating third-party software.
+
+- Foundational DevOps topics, such as branching strategies, continuous
+    integration (CI) and continuous delivery (CD).
+
+- This guide offers links to detailed resources on Microsoft Learn
+    rather than provide step-by-step instructions.
+
+## References
+
+1. [Software development handbook](../software-development-handbook/introduction.md)
+
+2. [How to request and manage software subscriptions](../software-subscriptions/introduction.md)  
+
+3. [Using Source Control](../using-source-control/introduction.md)
+
+4. [RESTful API Design and Build Standards](../restful-api-standards/introduction.md)
+
+5. [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+
+6. [General Coding Standards](../general-coding-standards/introduction.md)
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions. If a hyperlink is missing, search for the document in our Document Management System.
+
+## The need for guidance
+
+We use Azure DevOps to manage thousands of tasks, performed daily by
+hundreds of staff. Following good practice is essential to ensure
+consistent use across the organisation.
+
+This standard is designed to help you plan, build and release software
+in a way that enables seamless coordination across teams and boundaries.

--- a/doc/azure-devops-handbook/joining-an-existing-project.md
+++ b/doc/azure-devops-handbook/joining-an-existing-project.md
@@ -1,0 +1,75 @@
+# Joining an existing project
+
+Whether you're new to Azure DevOps or arranging access for others, start
+with these steps:
+
+## Find your project
+
+First, obtain your project URL. If needed, ask a colleague for help.
+Here are some common URLs:
+
+| **PROJECT URL** | **Description** |
+| --- | --- |
+| <https://dev.azure.com/NHS-Wales-Digital/WCP> | Welsh Clinical Portal |
+| <https://dev.azure.com/DHCW-DSPP/> | NHS App |
+| [https://dev.azure.com/NHS-Wales/DMTP](https://dev.azure.com/NHS-Wales/DMTP) | Digital Medicines Transformation Portfolio |
+| <https://dev.azure.com/NHS-Wales-CoE/> | M365 Centre of Excellence |
+
+!!! tip "Practical tips"
+    If you need to begin a project, see [Creating a Project](creating-a-new-project.md).
+
+!!! info "Further reading and information"
+    [Connect to your organisation - Azure DevOps Services \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/accounts/organization-management?view=azure-devops#connect-to-your-organization)
+
+## Check you have the right access level
+
+Next, check your *Access level.* *Access levels* control which **Azure
+DevOps** features you can use. If you don't have the right level you may
+be blocked from using Repos, Pipelines or Test Plans. Contact the
+*Organisation Owner* for more help.
+
+| **ACCESS LEVEL** | **FEATURES** |
+| --- | --- |
+| **Stakeholder** | Limited features for non-dev roles: create and view work items, basic project management; no access to Repos or Pipelines. |
+| **Basic** | Full access to Repos, Pipelines and Artifacts. |
+| **Basic + Test Plans** | All Basic features **plus** Azure Test Plans (Test planning, execution and reporting). |
+
+!!! tip "Practical tips"
+    **Subscriptions that grant access automatically**
+
+    Visual Studio Professional with GitHub Enterprise → **Basic**.
+
+    GitHub Enterprise Cloud → **Basic.**
+
+    Visual Studio Test Professional → **Basic + Test Plans**.
+
+!!! info "Further reading and information"
+    [How to request and manage software subscriptions](../software-subscriptions/introduction.md)
+
+    [Find or look up the organisation owner - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/look-up-organization-owner?view=azure-devops)
+
+    [About access levels - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/access-levels?view=azure-devops)
+
+    [Azure DevOps Basic usage included with GitHub Enterprise - Azure DevOps Blog](https://devblogs.microsoft.com/devops/azure-devops-basic-usage-included-with-github-enterprise/)
+
+## Verify access
+
+Finally, make sure you have the correct *Access permissions. Access
+permissions* control what you can do in a project. Ask a Project
+Administrator to update your access if needed.
+
+!!! tip "Practical tips"
+    If you click the project URL without the right access, you may be prompted to request access. Your request will be sent to the project administrator.
+
+!!! info "Further reading and information"
+    [Find a project administrator - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/look-up-project-administrators?view=azure-devops&tabs=preview-page)
+
+    [About permissions and security groups - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/about-permissions?view=azure-devops&tabs=preview-page)
+
+    [Troubleshoot access, permission issues - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/troubleshoot-permissions?view=azure-devops)
+
+## Additional steps
+
+If you're committing code to Azure Repos you may need to take some extra
+steps. See [Support & Troubleshooting](support-and-troubleshooting.md) for
+more details.

--- a/doc/azure-devops-handbook/managing-costs.md
+++ b/doc/azure-devops-handbook/managing-costs.md
@@ -1,0 +1,19 @@
+# Managing costs
+
+To control and optimise costs Organisation Owners **SHOULD:**
+
+- **Monitor Azure DevOps costs**: Review consumption costs against
+    your Azure subscription **weekly** to spot unexpected charges early.
+
+- **Downgrade or remove inactive users**: Downgrade inactive users to
+    Stakeholder after **8 weeks.** Remove users who haven't used Azure
+    DevOps for **6 months.**
+
+- **Set a monthly cost threshold:** Set alerts for when costs exceed a
+    threshold and review cost breakdowns in the \"*Cost Management +
+    Billing*\" section of the Azure portal.
+
+!!! info "Further reading and information"
+    [Manage paid access for users - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/billing/buy-basic-access-add-users?view=azure-devops)
+
+    [Billing FAQs (Frequently Asked Questions) - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/billing/billing-faq?view=azure-devops)

--- a/doc/azure-devops-handbook/managing-source-code-with-azure-repos.md
+++ b/doc/azure-devops-handbook/managing-source-code-with-azure-repos.md
@@ -1,0 +1,108 @@
+# Managing source code with Azure repos
+
+Following the practices in this section aligns with *[Using Source Control](../using-source-control/introduction.md)*, improving traceability, linking work items to code
+changes, and enhancing code quality.
+
+!!! info "Further reading and information"
+    [Using Source Control](../using-source-control/introduction.md)
+
+## How do you branch and release?
+
+You have freedom to choose your branching and release strategies, but
+you **SHOULD** follow these key practices to maintain simplicity and
+consistency:
+
+- **Use feature branches**: Develop new features and fix bugs in dedicated branches.
+
+- **Merge through pull requests (PRs)**: Integrate changes into the main branch using PRs.
+
+- **Keep the main branch clean**: Ensure the main branch is functional & up to date.
+
+- **Git Tagging:** Tag the release commit to ensure traceability and version identification.
+
+## Recommended naming conventions
+
+Name Git repositories in lowercase with hyphens. Prefixing with the
+Azure DevOps project or team name is **RECOMMENDED** but not required.
+
+| **COMPONENT** | **NAMING CONVENTION** | **examples** |
+| --- | --- | --- |
+| **REPOSITORY** | Lowercase, hyphens-separated\ <project-name\>:<purpose\> | wis-api welshpas-web wcp-integration-services |
+| **TAG** | <Major\>.<Minor\>.<Patch\> | 2.0.0 |
+
+Use this convention for branch names. You may not need them all, it
+depends on your strategy.
+
+| **BRANCH TYPE** | **NAMING CONVENTION** | **examples** |
+| --- | --- | --- |
+| **MAIN** | 'main' | main |
+| **DEVELOP** | 'develop' | develop |
+| **FEATURE** | feature/*<work-item-number\>-<feature-name\>* | feature/450447-add-cors-policy |
+| **RELEASE** | release/*<version-number\>* | release/2.0.0 |
+| **BUGFIX** | bugfix/*<issue-number\>-<description\>* | bugfix/46627-fix-SMS-Input-Error |
+| **HOTFIX** | hotfix/*<issue-number\>-<description\>* | hotfix/67891-critical-patch |
+
+!!! tip "Practical tips"
+    - Always link branches to corresponding work items,
+
+    - Delete redundant feature branches.
+
+## Configure repository settings for commit linking
+
+You **SHOULD** ensure these settings are applied across all branches:
+
+- **Enable Commit Mention Linking:** Automatically link commits to
+    work items by including the work item ID (e.g., #123) in the commit
+    message.
+
+- **Ensure Work Item Resolution:** Automatically update work item
+    status based on commit actions.
+
+## Configure repository policies for email validation
+
+- **Commit author email validation**: Block pushes from emails not
+    matching .\*@wales\\.nhs\\.uk\$
+
+## Configure branch policies
+
+Enable these settings on main and release branches to support effective
+branching and release:
+
+- **Require a minimum number of reviewers:** Ensure pull requests are
+    subject to code review.
+
+- **Require linked work items:** Ensure pull requests are linked to
+    work items.
+
+- **Require comments resolution:** Address comments before merging
+    pull requests.
+
+- **Enable Build Validation**: Trigger a build pipeline on pull
+    requests to validate code quality.
+
+- **Add a Code Coverage Status Check:** Ensure coverage targets are
+    met before merging.
+
+- **Set Coverage Thresholds:** Define differential (diff) thresholds
+    in *azurepipelines-coverage.yml* or *.runsettings* to match your
+    *Definition of Done*.
+
+- **Address Insufficient Coverage:** Use the "*Require comments
+    resolution*" policy to address any insufficient coverage before
+    merging.
+
+- **Review Coverage Thresholds**: Regularly review thresholds to meet
+    quality standards.
+
+!!! tip "Practical tips"
+    **Don't obsess over Code Coverage!**
+
+    Use it as a guide but focus on meaningful tests that ensure your code works as expected.
+
+!!! tip "Practical tips"
+    **Set Up Pipelines for Validation and Coverage**
+
+    Configure a build pipeline for validation and code coverage checks, In the next section, we'll show you how to set up pipelines for testing & deployment.
+
+!!! info "Further reading and information"
+    [Set Git repository settings - Azure Repos \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/repos/git/repository-settings?view=azure-devops&tabs=browser)

--- a/doc/azure-devops-handbook/managing-user-settings.md
+++ b/doc/azure-devops-handbook/managing-user-settings.md
@@ -1,0 +1,8 @@
+# Managing user settings
+
+Update your profile and interface preferences via the User settings icon
+in the top right corner. You can also access preview features to stay up
+to date.
+
+!!! tip "Practical tips"
+    Set your time zone to ***(UTC+00:00) Dublin, Edinburgh, Lisbon, London*** in *User Settings > Time and Locale* to ensure consistency.

--- a/doc/azure-devops-handbook/planning-and-tracking-work-with-azure-boards.md
+++ b/doc/azure-devops-handbook/planning-and-tracking-work-with-azure-boards.md
@@ -1,0 +1,113 @@
+# Planning and tracking work with Azure boards
+
+Following the practices described in this section aligns with *[Software development handbook](../software-development-handbook/introduction.md)*, helping you deliver incremental changes
+in time-boxed sprints.
+
+!!! info "Further reading and information"
+    [Software development handbook](../software-development-handbook/introduction.md)
+
+    [Agile Plan and Portfolio Management with Azure Boards - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/modules/plan-agile-github-projects-azure-boards/12-agile-plan-portfolio-management-azure-boards)
+
+## Backlog naming conventions
+
+The backlog is a list of work to complete*.* Prioritise work items based
+on business value, using parent-child relationships to maintain a clear
+hierarchy.
+
+Name items consistently to minimise misunderstandings and support
+automatic release notes generation. The following conventions are
+**RECOMMENDED**:
+
+| **WORK ITEM** | **TITLE CONVENTION** | **examples** |
+| --- | --- | --- |
+| **Epic** | Use action-oriented verbs to describe a high-level business initiative. | *Redesign the Authentication Flow for the NHS Wales Patient Portal.* |
+| **FEATURE** | Use outcome-driven language to describe smaller, deliverable functionality. | *Implement Multi-Factor Authentication for the NHS Wales Patient Portal login.* |
+| **USER STORY** | "As a \[persona\], I want \[something\] so that \[some reason\]\" | *As a user, I want to enter the SMS code I received so I can complete the authentication.* |
+| **TASK** | Use action-oriented verbs to describe work needed for a user story. | *Design UI for SMS code entry.* |
+| **BUG** | Focus on user impact and expected behaviour. | *Username field doesn't accept input after clicking, preventing login.* |
+| **ISSUE** | Clearly describe a problem or blocker. | *Need approval for UI colours.* |
+| **TEST PLAN** | High-level testing objectives, scope and activities. | *Validate Multi-Factor Authentication functionality, including SMS code input and error handling.* |
+| **TEST CASE** | A specific scenario to test. | *Verify SMS code input field.* |
+
+!!! info "Further reading and information"
+    [Use backlogs to manage projects - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/backlogs/backlogs-overview?view=azure-devops)
+
+    [Create your product backlog in Azure Boards - Azure Boards \| Microsoft Learn ](https://learn.microsoft.com/en-gb/azure/devops/boards/backlogs/create-your-backlog?view=azure-devops&tabs=agile-process)
+
+## Refine user stories
+
+Capture requirements in User Stories. When doing so:
+
+- Provide a concise description from the user's perspective.
+
+- Include clear acceptance criteria using Gherkin syntax to define 'done.'
+
+> {IMAGE PLACEHOLDER}
+
+!!! info "Further reading and information"
+    [Manage requirements, Agile - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/cross-service/manage-requirements?view=azure-devops&tabs=agile-process)
+
+## Link service requests
+
+For operational service requests, prefix a work item's title with the
+request ID and add a link to the request in the '*All Links'* tab.
+
+Alternatively consider using a custom process template with a *Change
+Reference* field. Contact your Organisation Owner for details.
+
+## Match work to the right Azure board
+
+Use *Kanban Boards* (Boards \> Boards) for continuous or unplanned work
+and *Task Boards* (Boards \> Sprints) for sprint tracking.
+
+Use tags, custom fields or queries to simplify navigation and reduce
+backlog clutter.
+
+!!! info "Further reading and information"
+    [Plan and track work in Azure Boards - Azure Boards \| Microsoft Lear n](https://learn.microsoft.com/en-gb/azure/devops/boards/get-started/plan-track-work?view=azure-devops&tabs=agile-process)
+
+    [Manage columns on your board - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/boards/add-columns?view=azure-devops&tabs=process-administrator#add-the-definition-of-done-to-a-column)
+
+    [Use your board - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/boards/kanban-quickstart?view=azure-devops)
+
+## Boards naming & style conventions
+
+Use these conventions to maintain consistency in how work items are
+represented:
+
+| **COMPONENT** | **CONVENTION / STYLE** | **examples** |
+| --- | --- | --- |
+| **TAGS** | *Use colours to indicate meaning.* | *Blocked* (Red), *External Dependency* (Blue), *Discovery* (Yellow) |
+| **CARD STYLE** | Priority = 1: Highlight high-priority items in Orange. | *Priority=1 (Orange)* |
+| **COLUMN NAMING** | Standardise naming across boards. | New, Active, Closed, Test |
+
+!!! info "Further reading and information"
+    [Customize cards on a board - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/boards/customize-cards?view=azure-devops)
+
+## Implement your definition of done
+
+Define shared criteria for each Board column and record it in the
+'*Definition of Done*' field.
+
+> {IMAGE PLACEHOLDER}
+
+!!! info "Further reading and information"
+    [Add Definition of Done to a column - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/boards/add-columns?view=azure-devops#add-definition-of-done-to-a-column)
+
+## Set-up delivery plans (optional)
+
+Delivery Plans track work across projects but are **NOT**
+**RECOMMENDED** if using tools like Float.
+
+!!! info "Further reading and information"
+    [Review team delivery plans in Azure Boards - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/plans/review-team-plans?view=azure-devops)
+
+## Drive development from work items
+
+Link work items to commits, branches, builds, and releases for better
+traceability and alignment between code and tasks. See [Link Work items
+to Builds](automating-builds-and-deployments-with-azure-pipelines.md) for more details.
+
+## Track progress of builds and releases
+
+Add status badges to a repos' README file to indicate code stability.

--- a/doc/azure-devops-handbook/project-housekeeping-tasks.md
+++ b/doc/azure-devops-handbook/project-housekeeping-tasks.md
@@ -1,0 +1,21 @@
+# Project housekeeping tasks
+
+Follow these **RECOMMENDED** practices to keep projects clean and
+well-organised:
+
+- **Set artifact retention policies** Keep only the **latest**,
+    **previous** and **active** releases versions to minimise storage
+    costs.
+
+- **Pipeline run retention:** Retain only recent, relevant runs for
+    debugging. Set retention policies to delete pipeline runs after
+    **30 days**.
+
+- **Delete obsolete branches**. Remove inactive or redundant branches
+    to remove clutter.
+
+- **Clean agent pools**: Clean stale directories and repositories on
+    self-hosted agents **weekly** to avoid disk space issues.
+
+- **Keep agents updated**: Enable automatic updates for minor version
+    changes and manually upgrade for major updates.

--- a/doc/azure-devops-handbook/securing-your-projects.md
+++ b/doc/azure-devops-handbook/securing-your-projects.md
@@ -1,0 +1,25 @@
+# Securing your projects
+
+You **MUST** follow these essential practices to ensure robust security:
+
+- Review permissions **monthly**, ensuring access follows the
+    *least-privilege principle*.
+
+- Remove permissions **as soon as** users no longer need access.
+
+- Use fine-grained permissions to restrict access to what's necessary.
+
+- Prefer *Federated Identity* over *Service Connections* when
+    possible.
+
+- Avoid *Personal Access Tokens (PATs)* but if used, recycle them
+    every ***90 days***.
+
+- Limit access to the minimum required for each user.
+
+!!! info "Further reading and information"
+    [Security best practices - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/security-best-practices?view=azure-devops)
+
+    [Other security considerations for Azure Pipelines - Azure Pipelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/pipelines/security/misc?view=azure-devops)
+
+    [Delete, remove users from team, project, organisation - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/accounts/delete-organization-users?view=azure-devops&tabs=browser)

--- a/doc/azure-devops-handbook/sharing-code-with-azure-artifacts.md
+++ b/doc/azure-devops-handbook/sharing-code-with-azure-artifacts.md
@@ -1,0 +1,133 @@
+# Sharing code with Azure artifacts
+
+Azure Artifacts provide a reliable way to store, version and distribute
+packages, like Nuget, across the organisation. You **SHOULD** follow
+these practices when using Artifacts in your Azure DevOps workflows.
+
+!!! info "Further reading and information"
+    [What is NuGet and what does it do? \| Microsoft Learn](https://learn.microsoft.com/en-gb/nuget/what-is-nuget)
+
+    [Azure Artifacts documentation \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/artifacts/?view=azure-devops)
+
+    [Omit NuGet Packages in Source Control Systems\| Microsoft Learn](https://learn.microsoft.com/en-gb/nuget/consume-packages/packages-and-source-control)
+
+    [Project-scoped vs Organisation-scoped feeds - Azure Artifacts \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/artifacts/feeds/project-scoped-feeds?view=azure-devops#project-scoped-vs-organization-scoped-feeds)
+
+    [Migrate from file shares - Azure Artifacts \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/artifacts/nuget/move-from-fileshares?view=azure-devops)
+
+    [Configure pipeline permissions - Azure Artifacts \| Microsoft Learn ](https://learn.microsoft.com/en-gb/azure/devops/artifacts/feeds/feed-permissions?view=azure-devops#pipelines-permissions)
+
+## Consuming packages
+
+- **Avoid Public Feeds**: Do not pull packages from public sources
+    like nuget.org. Use a secondary feed, *DHCW_Global_Dependencies*,
+    for shared or third-party dependencies.
+
+- **Minimise Duplication**: If a package is already in the
+    organisation feed, do not duplicate it in your local feed. This
+    saves storage costs and reduces redundancy.
+
+- **Keep Dependencies Updated**: Regularly check the
+    *DHCW_Global_Dependencies* feed for updates to keep your
+    dependencies current.
+
+- **Request Access Permissions**: If you need access to the
+    organisation feed, ask the organisation owner to grant the Build
+    Service User 'Contributor' permissions. The Build Service User is
+    the account running your Azure pipeline.
+
+!!! tip "Practical tips"
+    Granting access to an organisation feed is easier than a project feed, as it doesn't require first granting access to the project.
+
+    *DHCW_Global_Dependencies* is hosted in the NHS-Wales-Digital Azure DevOps Organisation but can be used by other Organisations in the same NHS Wales Entra tenant,
+
+!!! info "Further reading and information"
+    [Restore NuGet packages in Azure Pipelines - Azure Pipelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/pipelines/packages/nuget-restore?view=azure-devops&tabs=yaml#restore-nuget-packages-from-a-feed)
+
+    [Find or lookup the organisation owner - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/look-up-organization-owner?view=azure-devops)
+
+## Publishing packages
+
+Publishing packages to Azure Artifacts helps in:
+
+- Sharing secure, maintainable libraries (such as UI components).
+
+- Distributing validated third-party libraries without pulling from public feeds.
+
+!!! info "Further reading and information"
+    [Publish NuGet packages with Azure Pipelines - Azure Pipelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/pipelines/artifacts/nuget?toc=%2Fazure%2Fdevops%2Fartifacts%2Ftoc.json&bc=%2Fazure%2Fdevops%2Fartifacts%2Fbreadcrumb%2Ftoc.json&view=azure-devops&tabs=yaml)
+
+## How do you version your code?
+
+You **MUST** use Semantic Versioning (SemVer 2.0.0). See the following
+for more details:
+
+!!! info "Further reading and information"
+    [Using Source Control](../using-source-control/introduction.md)
+
+    [RESTful API Design and Build Standards](../restful-api-standards/introduction.md)
+
+    [Semantic Versioning 2.0.0 \| Semantic Versioning](https://semver.org/)
+
+## Versioning conventions
+
+| **COMPONENT** | **NAMING CONVENTION** | **example** |
+| --- | --- | --- |
+| **VERSION FORMAT** | <Major\> .<Minor\>.<Patch\>\[-<prerelease tag\>\]\[+<Git commit \>\] | 1.0.0 |
+| **MAJOR** | For breaking changes | 2.0.0 |
+| **MINOR** | Backward-compatible changes. | 2.1.0 |
+| **PATCH** | Bug Fixes | 1.0.1 |
+| **PRE-RELEASE TAG** | Optional \[-<alpha \| beta \ rc\>\] | 1.0.0-alpha |
+| **ALPHA** | Indicates unstable builds. | 1.0.0-alpha |
+| **BETA** | Feature complete but may contain known bugs. | 2.0.0-beta |
+| **RC** | Release candidate | 2.1.0-rc |
+| **Git Commit** | Short Git hash added after +. Identifies the build's source commit. | 1.0.0-alp ha+26be44c37e 2.0.0- beta+d8164225 |
+
+!!! tip "Practical tips"
+    Use the **Nerdbank.GitVersioning** dotnet tool to auto-generate SemVer compliant versions in Azure Pipelines.
+
+    Use extensions like **Generate Release Notes** in YAML Pipeline features to auto-generate package release notes.
+
+!!! info "Further reading and information"
+    <https://github.com/dotnet/Nerdbank.GitVersioning>
+
+## Package naming conventions
+
+Follow these naming conventions when publishing a package. Publish
+reusable components the organisation shared feed.
+
+| **COMPONENT** | **NAMING CONVENTION** | **example** |
+| --- | --- | --- |
+| **Organisation feed** | DHCW_Global_Dependencies | DHCW_Global_Dependencies |
+| **project feed** | <Project Name\> | NHS Wales Patient Portal |
+| **package ID** | \[<DHCW.\>\]<ProjectName\>.<ComponentName\> | DHCW.PortalUI.Validation |
+| **Package Version** | See [Publishing Packages: Versioning](#versioning-conventions) | 1.1.0 |
+| **AUTHORS** | Team or developer name | Phoenix Portal Team |
+| **DESCRIPTION** | A short description for UI display. | Validation library for UI components in the NHS Wales Patient Portal. This library..... |
+| **COPYright** | Copyright (c) DHCW <Year\> | Copyright (c) DHCW 2024 |
+| **Project URL** | Link to the Azure DevOps project | {base}/\_git/patient-portal |
+| **README** | Include a README markdown file | *(overview of what the package does)* |
+| **REPOSITORY URL** | A link to the source repository, including a 'type' attribute (e.g., git). | {base}/\_git/patient-portal |
+| **TAGS** | Comma-separated list of keywords. | UI, validation, Portal, .Net |
+| **RELEASE NOTES** | Description of changes in this release. | New release with added validation for SMS text input. |
+
+## Publishing to shared organisation feeds
+
+*DHCW_Global_Dependencies* (found in the NHS-Wales-Digital) uses only
+the \@local feed as the shared repository for stable packages. This
+simplifies package management.
+
+Follow these rules When publishing to a shared feed**:**
+
+1. **No Pre-releases:** Packages with pre-release tags (e.g., -alpha,
+    -beta, -rc) **MUST NOT** be published to a shared feed. Use
+    separate feeds for testing.
+
+2. **Stable Versions Only:** Ensure packages are fully tested,
+    reviewed, and stable before publishing.
+
+3. **Follow Conventions:** Adhere to semantic versioning (e.g., 1.0.0
+    for stable releases).
+
+!!! tip "Practical tips"
+    Automate checks in pipelines to block unstable versions from being published to the shared feed.

--- a/doc/azure-devops-handbook/support-and-troubleshooting.md
+++ b/doc/azure-devops-handbook/support-and-troubleshooting.md
@@ -1,0 +1,70 @@
+# Support and troubleshooting
+
+Azure DevOps requires minimal support, but issues can still arise.
+Follow these steps to get help:
+
+## General support
+
+- **Check Service Notifications**: For updates about issues or
+    disruptions.
+
+- **Check Microsoft Service Status**: Visit [Azure DevOps - Status](https://status.dev.azure.com/) for service updates.
+
+- **Monitor the Developer Channel**: Check the [Visual Studio Developer Azure DevOps Channel](https://developercommunity.visualstudio.com/AzureDevOps) to
+    upvote relevant issues.
+
+- **Ask a Project Admin**: Contact your Project Administrator if you
+    need further help.
+
+- **Contact the Organisation Owner**: For help with unresolved issues,
+    speak to the Organisation Owner who can raise a support request with
+    Microsoft.
+
+- **Log a Service Request:** If the Organisation Owner is unavailable
+    or your query is urgent, raise a service request (addressed to the
+    *Corporate Application* team). This option is only available to
+    users of the *NHS-Wales-Digital* Organisation.
+
+!!! info "Further reading and information"
+    [Find or lookup the organisation owner - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/look-up-organization-owner?view=azure-devops)
+
+    [Look up a project collection administrator - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/look-up-project-collection-administrators?view=azure-devops)
+
+## Unable to clone large Git repos
+
+Raise a service request to join the *NWI_Zscaler_Allow_AzureDevops Entra group*
+If you need to clone large repos. On approval, choose *Update Policy* in your
+zscaler desktop application.
+
+In the meantime, work around the issue using these commands:
+
+```sh
+    mkdir *<Repo Name>*
+
+    cd *<Repo Name>*
+
+    git init
+
+    git remote add origin *<Your repo URL>*
+
+    git pull # results in curl 56 failure.
+
+    git pull # succeeds.
+```
+
+## Fixing issues with SSL certificates
+
+Errors may occur if Git isn't configured to use the Windows Certificate
+Store for SSL verification:
+
+fatal: unable to access 'https://<your-repo-url\>': SSL certificate
+problem: unable to get local issuer certificate
+
+fatal: unable to access 'https://<your-repo-url\>': schannel
+CertGetCertificateChain trust error CERT_TRUST_IS_PARTIAL_CHAIN
+
+To fix them, run the following command in Git Bash. Alternatively, if
+you're using Visual Studio set the *cryptographic network provider* to
+*schannel* in the Git settings:
+
+`git config --global http.sslBackend schannel`

--- a/doc/azure-devops-handbook/using-azure-devops-extensions.md
+++ b/doc/azure-devops-handbook/using-azure-devops-extensions.md
@@ -1,0 +1,33 @@
+# Using Azure DevOps extensions
+
+Extensions add extra capabilities but require careful management. Follow
+these practices to manage them safely:
+
+- **Evaluate First:** Before requesting an extension, evaluate it
+    using Microsoft's criteria as extensions impact all users once
+    installed.
+
+- **Request Approval:** Consult the Organisation Owner before
+    requesting a new extension.
+
+- **Avoid Dependency:** Do not build critical workflows around
+    extensions. They are unsupported and may be removed at any time,
+    even if from Microsoft.
+
+- **Cybersecurity Approval:** Obtain approval from Cyber Security for
+    extensions accessing code repos or exporting telemetry.
+
+- **Disable telemetry:** Turn off telemetry and intrusive features.
+
+- **Audit Regularly:** Periodically review extensions to ensure
+      compliance with privacy and security policies.
+
+!!! tip "Practical tips"
+    The Organisation Owner may notify you of new extensions via banner notifications.
+
+!!! info "Further reading and information"
+    [Extensions overview - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/extend/overview?toc=%2Fazure%2Fdevops%2Fmarketplace-extensibility%2Ftoc.json&view=azure-devops)
+
+    [Extensions for Visual Studio family of products \| Visual Studio Marketplace](https://marketplace.visualstudio.com/azuredevops)
+
+    [Find or look up the organisation owner - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/look-up-organization-owner?view=azure-devops)

--- a/doc/azure-devops-handbook/using-wikis.md
+++ b/doc/azure-devops-handbook/using-wikis.md
@@ -1,0 +1,10 @@
+# Using wikis
+
+You **MAY** use Azure DevOps Wikis to record project information and
+decisions, but you **MUST NOT** use them for information that should be
+stored in a controlled document.
+
+!!! info "Further reading and information"
+    [Create a project wiki to share information - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/project/wiki/wiki-create-repo?view=azure-devops&tabs=browser)
+
+    [Share knowledge within teams - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/modules/share-knowledge-within-teams/)

--- a/doc/coding-standard-template/exceptions-prove-the-rule.md
+++ b/doc/coding-standard-template/exceptions-prove-the-rule.md
@@ -1,0 +1,7 @@
+# Exceptions prove the rule
+
+As with most standards, there are occasions when it's unwise to follow
+"hard and fast" rules.
+
+Principal and Lead software developers have discretion to do so but this
+should be the exception rather than the rule.

--- a/doc/coding-standard-template/good-practice-checklists.md
+++ b/doc/coding-standard-template/good-practice-checklists.md
@@ -1,0 +1,9 @@
+# Good practice checklists
+
+*<ADD TEXT AS NECESSARY\>*
+
+## <use a brief header to describe the checklist\>
+
+| Item |  |  | Guide or Standard | Exceptions |
+| --- | --- | --- | --- | --- |
+| 1 | *<ADD AS MANY CHECKLIST ITEMS AS NEEDED. WRITE THESE IN THE AFFIRMATIVE, RATHER THAN POSING THEM AS A QUESTION\>* | ☐ | <ADD A HYPERLINK TO THE STANDARD(S) YOU DESCRIBE IN SECTION 7) | *<ADD AS NEEDED\>* |

--- a/doc/coding-standard-template/introduction.md
+++ b/doc/coding-standard-template/introduction.md
@@ -1,0 +1,38 @@
+# Introduction
+
+## Purpose
+
+- *<BRIEFLY DESCRIBE THE PURPOSE OF HAVING A STANDARD\>*
+
+## Scope
+
+- *<OUTLINE THE SCOPE, WHAT'S INCLUDED, WHAT IS NOT\>*
+
+## References
+
+| INDEX NUMBER | DOCUMENT NAME |
+| --- | --- |
+|  | *<ADD DOCUMENT REFERENCES AND VERSION NUMBERS AS **REQUIRED**\>* |
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions
+
+## The need for guidance
+
+*<BRIEFLY DESCRIBE WHY THE STANDARD IS **REQUIRED**\>*

--- a/doc/coding-standard-template/use-a-brief-heading-to-describe-the-standards.md
+++ b/doc/coding-standard-template/use-a-brief-heading-to-describe-the-standards.md
@@ -1,0 +1,21 @@
+# <use a brief heading to describe the standard(s)\>
+
+*<DESCRIBE THE STANDARD\>*
+
+## <add subheading(s) if necessary\>
+
+*<ADD ANY ADDITIONAL TEXT AS NECESSARY\>*
+
+*<USE THE BELOW TO PROVIDE ANY RELEVANT EXAMPLES\>*
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! tip "Practical tips"
+    *<ADD ANY PRACTICAL TIPS YOU FEEL ARE PERTINENT\>*
+
+!!! info "Further reading and information"
+    *<ADD LINKS TO FURTHER INFROMATION AS **REQUIRED**. IF ADDING LINKS TO MICROSOFT DOCS, BE MINDFUL TO USE THE GB VERSION WHERE POSSIBLE.\>*

--- a/doc/general-coding-standards/analyse-your-code.md
+++ b/doc/general-coding-standards/analyse-your-code.md
@@ -1,0 +1,281 @@
+# Analyse your code
+
+## Create a plan
+
+You **MUST** conduct code analysis and address the issues you find.
+Doing this in both your IDE and build & integration pipelines will
+improve your code, making it easier to maintain, faster, and more
+secure.
+
+Code analysis can be complex, but this section outlines the steps you
+**SHOULD** follow. Create a tailored plan for your team that you
+regularly review and improve.
+
+!!! tip "Practical tips"
+    Use Redgate SQL Prompt to evaluate T-SQL. See the T-SQL coding standard for help.
+
+!!! info "Further reading and information"
+    [T-SQL Coding Standard](../t-sql-coding-standard/introduction.md)
+
+    [What is Static Analysis? An Explanation for Everyone - NDepend](https://blog.ndepend.com/static-analysis-explanation-everyone/)
+
+    [Enabling High-Quality Code in .NET \| Milan Milanović (milanovic.org)](https://milan.milanovic.org/post/enabling-high-code-quality-in-net/)
+
+## Calculate code metrics to spot problems
+
+Calculate code metrics for each project in your solution and address any
+that exceed acceptable limits. The table below shows **RECOMMENDED**
+levels for each metric.
+
+|  | **Maintainability Index** | **Cyclomatic Complexity** | **Depth of Imheritance** | **Class Coupling** | **Lines of Executable code** |
+| --- | --- | --- | --- | --- | --- |
+|  | 20 - 100 | < 7 | < 5 | < 9 | < 40 |
+
+## Calculate code coverage
+
+Calculate test coverage and use the results to identify areas for
+improvement.
+
+Generate and publish a code coverage report in your pipelines.
+
+!!! tip "Practical tips"
+    Aim to cover a large portion of your code with tests. But prioritise integration tests for areas prone to regressions. This may prove more effective than having unit tests for every method.
+
+    Note: Visual Studio's code coverage feature is available only in the Enterprise edition.
+
+!!! info "Further reading and information"
+    [Calculate code metrics - Visual Studio (Windows) \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/code-quality/code-metrics-values?view=vs-2022)
+
+    [Selective Unit Testing -- Costs and Benefits (stevensanderson.com)](http://blog.stevensanderson.com/2009/11/04/selective-unit-testing-costs-and-benefits/)
+
+    [Use code coverage for unit testing - .NET \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/core/testing/unit-testing-code-coverage?tabs=windows)
+
+    [Code coverage testing - Visual Studio (Windows) \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested?view=vs-2022&tabs=csharp)
+
+    [Publish Code Coverage Results task - Azure Pipelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/pipelines/tasks/test/publish-code-coverage-results?view=azure-devops)
+
+    [Exercise - Perform code coverage testing - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/modules/run-quality-tests-build-pipeline/6-perform-code-coverage)
+
+## Check code for style and quality
+
+Ensure your code follows the style ([naming](follow-microsofts-coding-conventions.md#naming),
+[layout](follow-microsofts-coding-conventions.md), [language](follow-microsofts-coding-conventions.md))
+and quality conventions described or referenced in this document.
+
+### Code Style Options and Analyser Rules
+
+Visual Studio offers a code style options box and Roslyn analyser code
+style rules. With newer versions of Visual Studio and the .NET SDK, you
+can run these rules at build time.
+
+Use the dotnet format tool in your build and integration pipelines to
+check for code style. See later in this section for details.
+
+## Use roslyn analysers to ensure .NET code quality
+
+Use Roslyn compiler analysers to check .NET code for style, quality,
+maintainability and other issues. They are available from Microsoft and
+third-party providers.
+
+**How Roslyn Analysers work**:
+
+- **Design-Time Analysis**: Analysers run on open files in the IDE,
+    providing immediate feedback.
+
+- **Build-Time Analysis**: Can be configured to run during builds to
+    enforce consistent standards.
+
+Use NuGet packages to integrate analysers directly in your code. Avoid
+relying solely on IDE-specific tools like Visual Studio extensions,
+ReSharper and SonarQube.
+
+### Default Analysers in .NET SDKs
+
+The latest .NET SDKs include many Roslyn analysers pre-installed. The
+image below shows the analysers available when creating an ASP.NET
+project targeting .NET 8.0 in Visual Studio.
+
+If using older SDKs, add analysers like
+Microsoft.CodeAnalysis.NetAnalyzers NuGet package.
+
+Figure 1 Use Roslyn analysers to check your code
+
+> {IMAGE PLACEHOLDER}
+
+### Third-party Analysers
+
+Include a security analyser, such as SonarAnalyzer.CSharp or
+SecurityCodeScan.VS2019. For assistance, ask the Software Development
+Manager or Cyber Security team.
+
+### Enabling Rules
+
+Roslyn analysers allow you to configure specific rules. In a .NET 6.0+
+project, created with Visual Studio, only a few rules are enabled by
+default. Enable all relevant rules, disabling only those that produce
+false positives or are not relevant.
+
+!!! tip "Practical tips"
+    **Introducing Code Analysis**: Enabling code analysis with all rules on a large codebase can be overwhelming. Start with a few rules and gradually add more until all are enabled.
+
+    **Important:** Code analysis may slow down your development environment. Balance error detection with productivity. Consider running resource-intensive analysis in build or integration pipelines.
+
+!!! info "Further reading and information"
+    [Seven reasons that Roslyn-based Code Analysers are awesome \| Tom Wrights Code (tdwright.co.uk)](https://blog.tdwright.co.uk/2018/12/10/seven-reasons-that-roslyn-based-code-analysers-are-awesome/?preview=true)
+
+    [The .NET Compiler Platform SDK (Roslyn APIs) \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/csharp/roslyn-sdk/)
+
+    [Code analysis documentation - Visual Studio (Windows) \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/code-quality/?view=vs-2022)
+
+    [Code analysers for .NET Framework \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/framework/code-analyzers#main)
+
+    [Legacy analysis for managed code - Visual Studio (Windows) \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/code-quality/static-code-analysis-for-managed-code-overview?view=vs-2022)
+
+    [Retrofitting code analysis to legacy projects -- (tdwright.co.uk)](https://blog.tdwright.co.uk/2018/12/13/retrofitting-code-analysis-to-legacy-projects-my-4-step-strategy-for-long-term-success/)
+
+    [Understanding the impact of Roslyn Analysers on build time - Meziantou's blog](https://www.meziantou.net/understanding-the-impact-of-roslyn-analyzers-on-the-build-time.htm)
+
+    [Favourite code analysis tools for .NET Core devs on Azure (zimmergren.net)](https://zimmergren.net/code-analysis-tools-for-azure-developers-coding-dotnet-core/)
+
+    **Roslyn Team analysers**
+
+    [NuGet Gallery \| Microsoft.CodeAnalysis.NetAnalyzers 9.0.0](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers#dependencies-body-tab)
+
+    [NuGet Gallery \| Roslyn Team](https://www.nuget.org/profiles/RoslynTeam)
+
+    **Roslynator**
+
+    [NuGet Gallery \| Roslynator.Analyzers 4 .12.10](https://www.nuget.org/packages/Roslynator.Analyzers/)
+
+    **xUnit**
+
+    [NuGet Gallery \| xunit.analyzers 1.19.0](https://www.nuget.org/packages/xunit.analyzers/)
+
+    **Style Cop**
+
+    [NuGet Gallery \| StyleCop.Analyzers 1.1.118](https://www.nuget.org/packages/StyleCop.Analyzers/)
+
+    **Security source code analysers**
+
+    [NuGet Gallery \| SonarAnalyzer.CSharp 10.5.0. 109200](https://www.nuget.org/packages/SonarAnalyzer.CSharp/)
+
+    [Static analysers - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/modules/static-analyzers/)
+
+    [NuGet Gallery \| SecurityCodeScan.VS2019 5.6.7](https://www.nuget.org/packages/SecurityCodeScan.VS2019/)
+
+    [Source Code Security Analysers \| NIST](https://www.nist.gov/itl/ssd/software-quality-group/source-code-security-analyzers)
+
+    [Source Code Analysis Tools \| OWASP Foundation](https://owasp.org/www-community/Source_Code_Analysis_Tools)
+
+    [Code analysis \| ReSharper (jetbrains.com)](https://www.jetbrains.com/help/resharper/Code_Analysis__Index.html) **ASP.NET analysers**
+
+    [Code analysis in ASP.NET Core apps \| Microsoft Learn](https://learn.microsoft.com/en-gb/aspnet/core/diagnostics/code-analysis?view=aspnetcore-6.0)
+
+    [Analysers for ASP.NET Core in .NET 6 (andrewlock.net)](https://andrewlock.net/exploring-dotnet-6-part-7-analyzers-for-minimal-apis/)
+
+    **ReSharper**
+
+    [Code analysis \| ReSharper (jetbrains.com)](https://www.jetbrains.com/help/resharper/Code_Analysis__Index.html)
+
+## Configure code analysis rules
+
+Follow these steps when configuring code analysis:
+
+| **CONFIGURATION STEP** | **Details** |
+| --- | --- |
+| **ADD AN .editorconfig FILE** | Place in the root of your solution and commit to source control to ensure consistent settings across the team. |
+| **SET-UP INITIAL RULES** | Generate settings using Visual Studio's code style options or a template (see further reading). Adjust rules to align with team or organisational conventions. |
+| **DEFINE RULE SEVERITY** | Set critical rules to *error* to ensure violations fail the build. Configure the Directory.build.props or .csproj files (SDK-style projects) to enable style and quality checks during builds. |
+| **ENFORCE CODE STYLE** | Enforce code style checks during builds where your .NET version supports it. |
+| **APPLY GOOD PRACTICE** | Treat warnings as errors to promote higher code quality. |
+
+!!! tip "Practical tips"
+    Be mindful of the challenges with .editorconfig, including known Visual Studio UI limitations. Read this blog before you start! --
+
+    [C# code style by EditorConfig in .NET 5 SDK and beyond \| Mews Developers](https://developers.mews.com/c-code-style-by-editorconfig-in-net-5-sdk-and-beyond/)
+
+You **MAY** develop team-specific styles if the provided conventions
+don't meet your needs.
+
+!!! note ".editorconfig"
+    [How to enforce a consistent coding style in your projects - Meziantou's blog](https://www.meziantou.net/how-to-enforce-a-consistent-coding-style-in-your-projects.htm)
+
+    [EditorConfig](https://editorconfig.org/)
+
+    [Code style options and code cleanup - Visual Studio (Windows) \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/ide/code-styles-and-code-cleanup?view=vs-2019)
+
+    [Enforce code style rules - Visual Studio (Windows) \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/ide/csharp-developer-productivity?source=recommendations&view=vs-2022#enforce-code-style-rules)
+
+    [.NET code style rule options - .NET \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/code-style-rule-options)
+
+    [C# editor formatting options - Visual Studio (Windows) \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/ide/reference/options-text-editor-csharp-formatting?view=vs-2022)
+
+!!! note ".editorconfig templates"
+    [EditorConfig settings - Visual Studio (Windows) \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/ide/create-portable-custom-editor-options?view=vs-2022)
+
+    [project-system/.editorconfig at main · dotnet/project-system · GitHub](https://github.com/dotnet/project-system/blob/main/.editorconfig)
+
+    [roslyn/.editorconfig at main · dotnet/roslyn · GitHub](https://github.com/dotnet/roslyn/blob/main/.editorconfig)
+
+!!! note ".csproj config"
+    [Code Analysis: MSBuild properties for Microsoft.NET.Sdk - .NET \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/core/project-sdk/msbuild-props#code-analysis-properties)
+
+    [Enable NET Analyzers: MSBuild properties for Microsoft.NET.Sdk - .NET \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/core/project-sdk/msbuild-props#enablenetanalyzers)
+
+    [C# Compiler Options - errors and warnings \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/csharp/language-reference/compiler-options/errors-warnings#treatwarningsaserrors)
+
+## Run code analysis in your pipelines as well as the IDE
+
+Run code analysis during builds catch issues early, using tools
+like **MSBuild** & **dotnet format**.
+
+!!! info "Further reading and information"
+    [Enforce .NET code style in CI with dotnet format - Meziantou's blog](https://www.meziantou.net/enforce-dotnet-code-style-in-ci-with-dotnet-format.htm#azure-pipelines)
+
+## Check third-party packages
+
+Check for vulnerabilities and licence issues in third-party dependencies
+by integrating tools like **GitHub Advanced Security for Azure DevOps**.
+
+!!! info "Further reading and information"
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [Software Composition Analysis - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/modules/software-composition-analysis/)
+
+## Publish and review metrics
+
+Track code health by publishing metrics from analysis tasks to server
+dashboards.
+
+Regularly review these metrics and address problem areas to maintain
+quality.
+
+!!! info "Further reading and information"
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [Generate code metrics from the IDE or command line - Visual Studio (Windows) \| Microsoft Learn ](https://learn.microsoft.com/en-gb/visualstudio/code-quality/how-to-generate-code-metrics-data?view=vs-2022)
+
+    [Publish Code Coverage Results task - Azure Pipelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/pipelines/tasks/test/publish-code-coverage-results?view=azure-devops)
+
+    [Exercise - Perform code coverage testing - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/modules/run-quality-tests-build-pipeline/6-perform-code-coverage)
+
+## Recap
+
+!!! note "Recap: Analyse your code"
+    1. Create a plan.
+
+    2. Calculate code metrics.
+
+    3. Calculate code coverage.
+
+    4. Check for code style and quality.
+
+    5. Use Roslyn analysers.
+
+    6. Configure code analysis rules.
+
+    7. Run code analysis in your build pipelines.
+
+    8. Check third party packages.
+
+    9. Publish metrics.

--- a/doc/general-coding-standards/essential-good-practice-checklist.md
+++ b/doc/general-coding-standards/essential-good-practice-checklist.md
@@ -1,0 +1,16 @@
+# Essential good practice checklist
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 1 | Your code is terse, expressive and underpinned with coded tests. | ☐ | [Write clean code](write-clean-code.md) | \- |
+| 2 | Classes follow SOLID principles. | ☐ | [Follow SOLID principles](follow-solid-principles.md) | \- |
+| 3 | You follow Microsoft's C# coding conventions and Framework Design Guidelines. | ☐ | [Follow Microsoft's coding conventions](follow-microsofts-coding-conventions.md) | *Unless you have agreed to follow a local coding standard.* |
+| 4 | You handle exceptions and use defensive coding techniques. | ☐ | [Exception handling and defensive coding](follow-microsofts-coding-conventions.md) | \- |
+| 5 | You calculate code metrics. | ☐ | [Calculate code metrics](analyse-your-code.md) |  |
+| 6 | You calculate code coverage. | ☐ | [Calculate code coverage](analyse-your-code.md) |  |
+| 7 | You analyse code for style and quality. | ☐ | [Check code for style and quality](analyse-your-code.md) |  |
+| 8 | You analyse code for security vulnerabilities. | ☐ | [Analyse your code](analyse-your-code.md) |  |
+| 9 | You share your analysis rules in source control. | ☐ | [Analyse your code](analyse-your-code.md) |  |
+| 10 | You perform code analysis in build pipelines. | ☐ | [Run code analysis in your pipelines](analyse-your-code.md#run-code-analysis-in-your-pipelines-as-well-as-the-ide) |  |
+| 11 | You check third party dependencies for security vulnerabilities. | ☐ | [Check third-party packages](analyse-your-code.md) |  |
+| 12 | You publish metrics to your dashboards. | ☐ | [Publish and review ,metrics](analyse-your-code.md) |  |

--- a/doc/general-coding-standards/examples.md
+++ b/doc/general-coding-standards/examples.md
@@ -1,0 +1,152 @@
+# Examples
+
+## Unnecessary using statements
+
+!!! danger "Examples of practices to avoid"
+    ```csharp
+        namespace Example
+        {
+            using System;
+            using System.Collections.Generic;
+
+            internal class BadClass
+            {
+                static void Main(string[] args)
+                {
+                    Console.WriteLine(“I'm using statements unnecessarily!”);
+                    Console.WriteLine(“I'm bad, shamone!”);
+                }
+            }
+        }
+    ```
+
+| **Rule ID** | **Rule Title** |
+| --- | --- |
+| [IDE0005](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/ide0005) | Using directive is unnecessary. |
+
+## Use our namespace conventions
+
+!!! example "Examples of good practice"
+    `NhsWales.Wcp.Portal`
+
+!!! danger "Examples of practices to avoid"
+    `DHCW.Wis.Reports`
+
+## Consider your use of var
+
+!!! example "Examples of good practice"
+    ```csharp
+        var patient = new Patient();
+
+        Patient myPatient = new Patient();
+    ```
+
+!!! danger "Examples of practices to avoid"
+    `#!csharp var patientCount = Ward.getPatientCount();`
+
+!!! example "Examples of good practice"
+    `#!csharp int patientCount = Ward.getPatientCount();`
+
+!!! danger "Examples of practices to avoid"
+    `#!csharp var myPatient = Demographics.getPerson(NHSNumber);`
+
+!!! example "Examples of good practice"
+    `#!csharp Person myPatient = Demographics.getPerson(NHSNumber);`
+
+## Name parameters
+
+!!! example "Examples of good practice"
+    `#!csharp var permissions = getUsersAccessPermissions("ge000001", isLoggedIn: true);`
+
+!!! danger "Examples of practices to avoid"
+    `#!csharp var permissions = getUsersAccessPermissions("ge000001", true);`
+
+!!! tip "Practical tips"
+    Enable Visual Studio's inline parameter hints to show argument names before function call arguments
+
+## Prioritise readability over brevity
+
+!!! danger "Examples of practices to avoid"
+    `#!csharp SearchOnUserName(string id);`
+    `#!csharp SearchOnUsersFullName(string nadexID);`
+
+!!! example "Examples of good practice"
+    `#!csharp SearchOnUsersFullName(string activeDirectoryUserId);`
+
+## Use underscores only in unit test names
+
+!!! example "Examples of good practice"
+    `#!csharp SearchOnUsersFullName_ValidActiveDirectoryUserIdProvided\_ReturnsUsersFullName()`
+
+!!! danger "Examples of practices to avoid"
+    `#!csharp Search_On_UsersFullName(string activeDirectoryUserId);`
+
+## Ensure boolean names are phrased as questions
+
+!!! example "Examples of good practice"
+    `#!csharp bool IsTrue;`
+
+!!! danger "Examples of practices to avoid"
+    `#!csharp bool condtionChecker;`
+
+!!! example "Examples of good practice"
+    `#!csharp bool IsOpen;`
+
+!!! danger "Examples of practices to avoid"
+    `#!csharp bool open;`
+
+!!! example "Examples of good practice"
+    `#!csharp bool IsActive;`
+
+!!! danger "Examples of practices to avoid"
+    `#!csharp bool status;`
+
+## Use prefixes and suffixes only when specified by conventions
+
+!!! danger "Examples of practices to avoid"
+    ```csharp
+        string strActiveDirectoryUserId;
+
+        int iPatientCount;
+
+        var iPatientCount;
+
+        GetUsersFullName(string p_activeDirectoryUserId);
+    ```
+
+!!! example "Examples of good practice"
+    | **Prefix** | **Usage** | **Language** |
+    |--- | --- | --- |
+    | **I** | **Interface** definitions | *C#* |
+    | **T** | Generic **Type** definitions. Simply use T if only one Type is defined. | *C#* |
+    | **T** | Type definitions | *Delphi* |
+    | **P** | **Pointers** to *Type* definitions | *Delphi* |
+    | **A** | Use to distinguish parameters with the same name as private member variables. | *Delphi* |
+
+## Using braces
+
+!!! danger "Examples of practices to avoid"
+    ```csharp
+        if (isLoggedIn)
+            DisplayHomePage();
+
+        if (isLoggedIn) DisplayHomePage();
+    ```
+    
+!!! example "Examples of good practice"
+    ```csharp
+        if (isLoggedIn)
+        {
+            DisplayHomePage();
+        }
+
+        if (isLoggedIn) { DisplayHomePage(); }
+    ```
+
+| **Rule ID** | **Rule Title** |
+| --- | --- |
+| [IDE0011](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/ide0011) | Add braces to 'if' statement. |
+
+## Code comments
+
+> {IMAGE PLACEHOLDER}

--- a/doc/general-coding-standards/exceptions.md
+++ b/doc/general-coding-standards/exceptions.md
@@ -1,0 +1,16 @@
+# Exceptions
+
+While there may be reasons to deviate from this guide, exceptions should
+be rare and carefully considered.
+
+!!! tip "Practical tips"
+    Discuss with colleagues and hold code reviews to ensure a shared understanding of our standards.
+
+!!! info "Further reading and information"
+    [Giving code a good name - Kevlin Henney - YouTu be](https://www.youtube.com/watch?v=CzJ94TMPcD8)
+
+    [Clean Coders Hate What Happens to Your Code When You Use These Enterprise Programming Tricks - YouTu be](https://www.youtube.com/watch?v=FyCYva9DhsI)
+
+    [Seven ineffective coding habits of many programmers - Kevlin Henney - YouTu be](https://www.youtube.com/watch?v=oyyFKHpzL0Q)
+
+    [Uses and misuses of implicit typing \| Microsoft Learn](https://learn.microsoft.com/en-gb/archive/blogs/ericlippert/uses-and-misuses-of-implicit-typing)

--- a/doc/general-coding-standards/follow-microsofts-coding-conventions.md
+++ b/doc/general-coding-standards/follow-microsofts-coding-conventions.md
@@ -1,0 +1,209 @@
+# Follow microsoft's coding conventions
+
+Follow Microsoft's [C# coding
+conventions](https://learn.microsoft.com/en-gb/dotnet/csharp/fundamentals/coding-style/coding-conventions)
+and [Framework Design
+Guidelines](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/).
+There are a couple of exceptions, but we make these clear.
+
+!!! tip "Practical tips"
+    If the conventions described here do not meet your team's needs and you want to create your own, please speak to the Software Development Manager.
+
+## Naming
+
+You **SHOULD**:
+
+- Follow Microsoft's naming conventions, considering our additional
+    guidance.
+
+- Use Attribute and Exception suffixes only when they clarify intent.
+
+- Apply Roy Osherove's naming convention for tests, allowing
+    underscores. See our [examples](examples.md).
+
+- Use NhsWales for the company name in namespaces. See [examples](examples.md).
+
+- Name booleans to reflect true/false questions. See [examples](examples.md).
+
+You **SHOULD NOT**:
+
+- Use "And", "Or" or generic terms like "Util" or "Common" in
+    class names.
+
+- Add prefixes or suffixes except where standard conventions apply.
+      See our [examples](examples.md).
+
+!!! info "Further reading and information"
+    [C# Naming Conventions \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/csharp/fundamentals/coding-style/coding-conventions#naming-conventions)
+
+    [Naming Guidelines - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/naming-guidelines)
+
+    [Capitalisation Conventions - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/capitalization-conventions)
+
+    [General Naming Conventions - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/general-naming-conventions)
+
+    [Names of Assemblies and DLLs - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/names-of-assemblies-and-dlls)
+
+    [Names of Namespaces - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/names-of-namespaces)
+
+    [Names of Classes, Structs, and Interfaces - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces)
+
+    [Names of Type Members - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/names-of-type-members)
+
+    [Naming Parameters - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/naming-parameters)
+
+    [Naming Resources - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/naming-resources)
+
+## Layout
+
+You **SHOULD:**
+
+- Follow Microsoft's layout conventions.
+
+- Use continuation lines to avoid excessive scrolling and indent with
+    four spaces.
+
+- Indent wrapped statements to keep logically related segments
+    aligned.
+
+- Use whitespace effectively to enhance readability.
+
+- Insert empty lines to separate code blocks.
+
+- Align curly braces vertically.
+
+For C#, place each curly brace on a new line, aligned with the start of
+the code block.
+
+For JavaScript and Razor, place the opening curly brace on the same line
+as the construct to prevent issues with automatic semicolon insertion.
+Exceptions apply in specific cases.
+
+You **SHOULD NOT:**
+
+- Use unnecessary vertical whitespace -- and so prevent extra
+    scrolling.
+
+- Overuse indentation.
+
+- Omit optional curly braces, as this increases error risk. Use them
+      judiciously when it improves readability. See [examples](examples.md).
+
+!!! info "Further reading and information"
+    [C# Layout Conventions \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/csharp/fundamentals/coding-style/coding-conventions#layout-conventions)
+
+## Comments
+
+You **SHOULD**:
+
+- Follow Microsoft's commenting conventions.
+
+- Use comments to explain the problem your code solves, not the code
+      itself.
+
+- Write expressive, readable code.
+
+- Prefer automated tests rather than rely on code comments or
+      excessive documentation.
+
+- Remove unused code instead of commenting it out. See
+      [examples](../t-sql-coding-standard/code-comments.md).
+
+- Add comments to code commits, following the Conventional Commits
+      specification.
+
+- Use well-named automated tests as part of your documentation (see
+      [naming](../restful-api-standards/naming.md) guidelines).
+
+- Use enumerations to self-document code and make it searchable in
+      Visual Studio.
+
+- Ensure comments are grammatically correct and properly punctuated.
+
+You **SHOULD NOT**:
+
+- Comment to explain how C# or the .NET Class Library works.
+
+- Add unnecessary or redundant comments. For example, at the top of
+      methods or classes. Provide a concise summary instead.
+
+!!! info "Further reading and information"
+    [.NET Coding Conventions - C# - comment style \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/csharp/fundamentals/coding-style/coding-conventions#comment-style)
+
+    [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+
+## Variables and parameters
+
+You **SHOULD**:
+
+- Declare C# variables close to where they are used.
+
+- Initialize variables at the point of declaration, when possible.
+
+- Declare JavaScript variables at the top of their scope and consider
+      using 'strict mode' to prevent hoisting.
+
+- Order parameters consistently.
+
+- Use named parameters to improve code readability. See [examples](examples.md).
+
+- Avoid methods with more than three parameters.
+
+You **SHOULD NOT**:
+
+- Declare all variables at the beginning of a class out of habit.
+
+!!! info "Further reading and information"
+    [Member Design Guidelines - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/member)
+
+    [Understanding Hoisting in JavaScript \| DigitalOcean](https://www.digitalocean.com/community/tutorials/understanding-hoisting-in-javascript)
+
+## Conditionals and control flow statements
+
+You **SHOULD:**
+
+- Define conditionals in the positive (see examples).
+
+- Prefer constants or enumerations over hard-coded numerical values
+    ('magic numbers'). Use named constants to improve readability.
+
+- Order case/switch statements logically and always include a default
+    statement.
+
+- Ensure conditionals are clear and easy to understand.
+
+- Minimise nested conditionals where possible.
+
+!!! tip "Practical tips"
+    Where practical, place enumerations in a namespace in their own code file.
+
+!!! info "Further reading and information"
+    [C# static code analysis- Magic numbers should not be used](https://rules.sonarsource.com/csharp/RSPEC-109/)
+
+## Exception handling and defensive coding
+
+You **SHOULD**:
+
+- Implement a global exception handler.
+
+- Move complex code out of try blocks into separate methods.
+
+- Handle exceptions locally, when possible, but avoid catching
+    unresolvable exceptions -- let them bubble up to the global handler.
+
+- Log exceptions with relevant details, including stack trace and
+    context.
+
+- Use guard clauses to validate inputs early.
+
+- Use multiple return statements to avoid deep indentation.
+
+- Avoid silent exceptions -- always log or rethrow as needed.
+
+- Catch specific, rather than generic, exceptions for precise
+    handling.
+
+- Test exception handling to ensure proper behaviour, especially in edge cases.
+
+!!! info "Further reading and information"
+    [Best Practices for exceptions - .NET \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/exceptions/best-practices-for-exceptions)

--- a/doc/general-coding-standards/follow-solid-principles.md
+++ b/doc/general-coding-standards/follow-solid-principles.md
@@ -1,0 +1,15 @@
+# Follow SOLID principles
+
+Following SOLID principles decouples code from dependencies, improving
+testability and maintainability. You **SHOULD**:
+
+- Apply SOLID principles for object-oriented programming.
+
+- Ensure classes and methods have a single responsibility.
+
+- Code to interfaces where appropriate.
+
+- Use Inversion of Control (IoC) and IoC containers to decouple implementations.
+
+!!! info "Further reading and information"
+    [Class design guidelines for .NET - Framework Design Guidelines \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/design-guidelines/type)

--- a/doc/general-coding-standards/introduction.md
+++ b/doc/general-coding-standards/introduction.md
@@ -1,0 +1,54 @@
+# Introduction
+
+## Purpose
+
+Describes the general coding standard for the Operations and Primary
+Care & Mental Health directorates.
+
+## Scope
+
+### In-scope
+
+- Software development within the Operations and Primary Care and
+    Mental Health directorates.
+
+- Recommended conventions and naming standards.
+
+- [Good practice](../restful-api-standards/essential-good-practice-checklist.md) checklist.
+
+### Out-of-scope
+
+- Developers not using C#.NET may need to adapt this guide or follow a
+    local coding standard.
+
+## References
+
+1. [T-SQL Coding Standard](../t-sql-coding-standard/introduction.md)
+2. [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions. If a hyperlink is missing, search for the document in our Document Management System.
+
+## The need for guidance
+
+Use this standard to:
+
+- Write consistent code, making it easier to understand.
+
+- Create software that is maintainable, efficient, and secure.

--- a/doc/general-coding-standards/write-clean-code.md
+++ b/doc/general-coding-standards/write-clean-code.md
@@ -1,0 +1,27 @@
+# Write clean code
+
+Your code **SHOULD**:
+
+- Be concise, expressive and focused on doing one thing well.
+
+- Use short methods (20-40 lines) with a single purpose.
+
+- Include written tests, be self-documenting and easy to read.
+
+- Have classes with high cohesion, containing clearly related methods that share class properties.
+
+- Prefer using or import statements instead of fully qualified type names.
+
+Your code **SHOULD NOT**:
+
+- Contain unused using (Java) or import (C#) statements.
+
+!!! tip "Practical tips"
+    Use the using static directive (C#6) to ensure method names are prefixed with their class for clarity.
+
+    Consider global using directives and implicit usings to reduce clutter and improve readability.
+
+!!! info "Further reading and information"
+    [Create readable code with conventions, whitespace, and comments in C# - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/modules/csharp-readable-code/)
+
+    [Welcome to C# 10 - .Net Blog (Microsoft.com)](https://devblogs.microsoft.com/dotnet/welcome-to-csharp-10/)

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,13 +1,13 @@
 # Software development handbook
 
-This site shares Digital Health and Care Wales' (DHCW) software development standards. 
+This site shares Digital Health and Care Wales' (DHCW) software development standards.
 Until now, these have only been available to internal staff.
 
-### Why have a handbook?
+## Why have a handbook?
 
-When you're building software, especially in healthcare, good guidance really matters. It helps everyone work in a consistent way, so the code is easier to understand, safer, and more reliable. 
+When you're building software, especially in healthcare, good guidance really matters. It helps everyone work in a consistent way, so the code is easier to understand, safer, and more reliable.
 
-A handbook brings together all the important know-how: how to write clear, secure code; how to manage changes properly; how to work well across teams; and how to meet the expectations of modern software development. 
+A handbook brings together all the important know-how: how to write clear, secure code; how to manage changes properly; how to work well across teams; and how to meet the expectations of modern software development.
 
 It's there to help you make good decisions, avoid mistakes, and deliver software that others can trust and build on.
 
@@ -16,9 +16,6 @@ It's there to help you make good decisions, avoid mistakes, and deliver software
 
     The key words **"MUST"**, **"MUST NOT"**, **"REQUIRED"**, **"SHALL"**, **"SHALL NOT"**, **"SHOULD"**, **"SHOULD NOT"**, **"RECOMMENDED"**, **"MAY"**, and **"OPTIONAL"** in this handbook are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
-
-### Contributing
+## Contributing
 
 Thanks for your interest in contributing! We're still working out how we’d like to manage contributions. In the meantime, we’d love to hear your ideas—please feel free to open an issue with any suggestions. We'll share proper contribution guidelines soon.
-
-

--- a/doc/organising-your-solution/create-a-editorconfig-file.md
+++ b/doc/organising-your-solution/create-a-editorconfig-file.md
@@ -1,0 +1,5 @@
+# Create a .editorconfig file
+
+You **SHOULD** share your configuration by adding an. editorconfig file
+to the root of your solution, making sure to add it to source control.
+For more details, see our *General coding standard* (v4 or later).

--- a/doc/organising-your-solution/create-a-root-folder-for-your-solution.md
+++ b/doc/organising-your-solution/create-a-root-folder-for-your-solution.md
@@ -1,0 +1,13 @@
+# Create a *root* folder for your solution (./<rootfoldername\>)
+
+You **SHOULD** place your solution file in a root folder. Doing so makes
+it easy for others to clone a repo and open the file to get started. The
+rest of the software project lives within this root folder.
+
+Provide a sensible name, using the name of the git repo or the solution
+file.
+
+!!! tip "Practical tips"
+    If the RootFolderName does not describe the project, replace it with something more accurate and understandable.
+
+    Do this before you commit to source control. In doing so you avoid the need for communicating a change and making source control work overtime after the initial commit.

--- a/doc/organising-your-solution/create-a-source-folder.md
+++ b/doc/organising-your-solution/create-a-source-folder.md
@@ -1,0 +1,5 @@
+# Create a source folder (./<rootfoldername\>/src)
+
+You **SHOULD** store all projects that have a definable output release
+(for example, web, desktop, mobile or general library projects) in a
+source folder, named *src*.

--- a/doc/organising-your-solution/create-a-specification-folder.md
+++ b/doc/organising-your-solution/create-a-specification-folder.md
@@ -1,0 +1,9 @@
+# Create a specification folder (./<rootfoldername\>/specs)
+
+You **SHOULD** store test projects and any specifications you consider
+valuable in a specification ('specs') folder. Keeping them together
+helps link your documentation to tests.
+
+You **SHOULD** clearly indicate the expected behaviours, functionality
+and actual integration with consumers of the code. This may include data
+extracts from other systems or software.

--- a/doc/organising-your-solution/exceptions-prove-the-rule.md
+++ b/doc/organising-your-solution/exceptions-prove-the-rule.md
@@ -1,0 +1,7 @@
+# Exceptions prove the rule
+
+As with most standards, there are occasions when it's unwise to follow
+"hard and fast" rules.
+
+Principal and Lead software developers have discretion to do so but this
+should be the exception rather than the rule.

--- a/doc/organising-your-solution/good-practice-checklists.md
+++ b/doc/organising-your-solution/good-practice-checklists.md
@@ -1,0 +1,21 @@
+# Good practice checklists
+
+Use this checklist to demonstrate you follow our coding standards.
+
+We cross-reference each checklist item to a relevant section in our
+standards and guides; Exceptions are noted where they may apply.
+
+## Folder structure good practice
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 1 | You use physical folders to separate logical areas of your software solution | ☐ | [*Use physical folders*](use-physical-folders.md) |  |
+| 2 | You include a README markdown file, instructing others on how to build and deploy your software solution | ☐ | [*Provide a README file*](provide-a-readme-file.md) |  |
+| 3 | You include a .editorconfig to allow your code style rules to be shared | ☐ | [*Provide a .editorconfig file*](create-a-editorconfig-file.md) |  |
+| 4 | You include a *source* folder | ☐ | [*Include a source folder*](create-a-source-folder.md) |  |
+| 5 | You create subfolders to separate dependency layers | ☐ | [*Use additional subfolders for dependency layers*](use-additional-sub-folders-for-dependency-layers.md) |  |
+| 6 | You include a *documents* folder | ☐ | [*Include a documents folder*](provide-a-documents-folder.md) |  |
+| 7 | You include folder for coded tests | ☐ | [*Include a test folder*](provide-a-test-folder.md) |  |
+| 8 | You include a *builds* folder | ☐ | [*Include a build folder*](provide-a-build-folder.md) |  |
+| 9 | You include a *deploy* folder | ☐ | [*Include a deploy folder*](provide-a-deploy-folder.md) | May only be required if deploying to cloud |
+| 10 | You provide examples with your solution | ☐ | [*Include an examples folder*](provide-an-examples-folder.md) |  |

--- a/doc/organising-your-solution/introduction.md
+++ b/doc/organising-your-solution/introduction.md
@@ -1,0 +1,55 @@
+# Introduction
+
+## Purpose
+
+Describes the Application Development and Support Directorate's standard
+for organising your software solution.
+
+## Scope
+
+Software Developers have a responsibility to follow this guide.
+
+Developers targeting frameworks other than .NET may need to make
+sensible adjustments where necessary.
+
+## References
+
+* [General Coding Standards](../general-coding-standards/introduction.md)
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions
+
+    **Note** that all links to Microsoft Learn© may default to *Azure DevOps Services.* Use its version selector to tailor the website for *Azure DevOps Server.*
+
+## The need for guidance
+
+Modern programming practices expect us to prove that our code meets
+functional requirements and can be reliably built and deployed.
+
+This requires a little forethought when creating a solution that others
+will use (often without the originating developer present.) So, it's
+critical we create software solutions that are:
+
+* Clear and explicit
+
+* Understandable by developers of all abilities
+
+* Safely extensible & well documented
+
+The following sections provide guidance on how we can achieve this.

--- a/doc/organising-your-solution/organise-your-solution-to-accord-with-our-conventions.md
+++ b/doc/organising-your-solution/organise-your-solution-to-accord-with-our-conventions.md
@@ -1,0 +1,75 @@
+# Organise your solution to accord with our conventions
+
+You **SHOULD** organise your solution according to our standards. They
+follow those used by many language ecosystems, including the .NET source
+code itself. Note that they differ from the typical Visual Studio *File
+New* defaults.
+
+There are two choices, as shown below. This document describes the
+first, which suits a Behavioural Driven Development \[BDD\] approach.
+But they are very similar and equally valid.
+
+Organizing your software solution - option #1 (suits a BDD approach):
+
+!!! example "Examples of good practice"
+    ```sh
+        └──{RootFolderName}/        # Root folder for your entire software solution
+            ├── deploy/             # Any infrastructure provisioning scripts
+            ├── build/              # Any published build outputs
+            │   └── scripts/        # Build scripts and CI scripts not required in the root
+            ├── examples/           # Samples and demos on how to build or consume your app
+            ├── specs/              # Container folder for tests and documentation
+            │   ├── docs/           # Diagrams, specifications and documentation
+            │   └── test/           # Automated tests and feature files
+            ├── src/                # Source code separated by dependency layer subfolders
+            ├── README.md           # Starting point for anyone building or using your software
+            ├── .editorconfig       # Enforces a consistent coding style for your project
+            └── {SolutionName}.sln  # Solution file
+    ```
+
+Organizing your software project - option #2:
+
+!!! example "Examples of good practice"
+    ```sh
+        └──{RootFolderName}/        # Root folder for your entire software solution
+            ├── deploy/             # Any infrastructure provisioning scripts
+            ├── build/              # Any published build outputs
+            │   └── scripts/        # Build scripts and CI scripts not required in the root
+            ├── docs/               # Diagrams, specifications and documentation
+            ├── examples/           # Samples and demos on how to build or consume your app
+            ├── src/                # Source code separated by dependency layer subfolders
+            ├── test/               # Automated tests
+            ├── README.md           # Starting point for anyone building or using your software
+            ├── .editorconfig       # Enforces a consistent coding style for your project
+            └── {SolutionName}.sln  # Solution file
+    ```
+
+An Example .Net Solution which follows our conventions:
+
+> {IMAGE PLACEHOLDER}
+
+!!! tip "Practical tips"
+    - Use the approach that best matches your needs
+
+    - In later versions of .NET use C:\\> dotnet new gitignore to generate a .gitignore file
+
+    - Clone our example project structure from the Software Development Standards project in Azure DevOps.
+
+!!! info "Further reading and information"
+    [An Opinionated Approach to ASP.NET Core - Scott Allen - YouT ube](https://www.youtube.com/watch?app=desktop&v=6Fi5dRVxOvc)
+
+    [.NET Core Opinion #1 - Structuring a Repository (odetocode.com)](https://odetocode.com/blogs/scott/archive/2018/08/28/net-core-opinion-1-structuring-a-repository.aspx)
+
+    [.NET Core Opinion #2 - Managing a Repository Structure (odetocode .com)](https://odetocode.com/blogs/scott/archive/2018/09/06/net-core-opinion-2-ndash-managing-a-repository-structure.aspx)
+
+    [.NET Core Opinion #3 - Other Folders to Include in the Source Repository (od etocode.com)](https://odetocode.com/blogs/scott/archive/2018/09/13/net-core-opinion-3-ndash-other-folders-to-include.aspx)
+
+    [Create .NET Projects Using Standard Practices \| Toptal](https://www.toptal.com/dot-net/bootstrap-and-create-dot-net-projects)
+
+    [Common web application architectures \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/architecture/modern-web-apps-azure/common-web-application-architectures)
+
+    [Behaviour-Driven Development - Cucumber Documentation](https://cucumber.io/docs/bdd/)
+
+    [.NET project structure · Gi tHub](https://gist.github.com/davidfowl/ed7564297c61fe9ab814)
+
+    [GitHub - github/gitignore: A collection of useful .gitignore templates](https://github.com/github/gitignore)

--- a/doc/organising-your-solution/provide-a-build-folder.md
+++ b/doc/organising-your-solution/provide-a-build-folder.md
@@ -1,0 +1,8 @@
+# Provide a build folder (./<*rootfoldername\>/*build)
+
+You **SHOULD** store the latest output from publish commands, though not
+necessarily each build event, in a build folder.
+
+Place your outputs in sub folders, named appropriately, with a suffix to
+indicate output type and a prefix for the solution name. And take care
+to indicate the last build date.

--- a/doc/organising-your-solution/provide-a-deploy-folder.md
+++ b/doc/organising-your-solution/provide-a-deploy-folder.md
@@ -1,0 +1,6 @@
+# Provide a deploy folder (./<*rootfoldername\>/*deploy)
+
+You **SHOULD** store any infrastructure provisioning scripts in a deploy
+folder. These could be Azure Resource Management (ARM) templates or
+Bicep scripts and associated parameter files, but it is **RECOMMENDED**
+that you use Terraform scripts.

--- a/doc/organising-your-solution/provide-a-documents-folder.md
+++ b/doc/organising-your-solution/provide-a-documents-folder.md
@@ -1,0 +1,38 @@
+# Provide a documents folder (.*/<rootfoldername\>/*specs*/*docs)
+
+You **SHOULD** keep documentation you consider valuable (including
+diagrams, specifications[^1] and documents relevant to build output) in
+a documents ('docs') folder. This is particularly useful if there's no
+Solutions Architecture Design document (SAD) or Software Requirements
+Specification (SRS).
+
+While most documents **MAY** be stored in our document management
+system, not all will reflect the current state of the solution. For
+example, a SAD or SRS may include planned work or perhaps even obsolete
+design decisions. Maintaining a *docs* folder is an important step in
+addressing any drift between design and build.
+
+You **SHOULD NOT** let documentation become stale or out-of-step with
+the build output or use the docs folder as a replacement for the
+corporate document management system.
+
+!!! tip "Practical tips"
+    - Use automation. For example, generate .pdf files from the repo's markdown files and include OpenAPI documentation.
+
+    - Take care when linking to other documents. Links are only relevant while they are maintained and may be resolvable only from within our domain.
+
+    - Encourage testers and business analysts to use. feature files to record changes to requirements. Link your docs folder to those*. feature* files
+
+    - Use a tool like [Grammarly: Free Online Writing Assistant](https://www.grammarly.com/) to help you make your content clear
+
+Writing good documentation is a skill. Use these links to help you write
+high quality documentation.
+
+!!! info "Further reading and information"
+    [Doing Visual Studio and .NET Code Documentation Right \-- Visual Studio Magazine](https://visualstudiomagazine.com/articles/2017/02/21/vs-dotnet-code-documentation-tools-roundup.aspx)
+
+    [How to write plain English](https://www.plainenglish.co.uk/)
+
+    [Writing checklist (sharepoint.com)](https://nhswales365.sharepoint.com/sites/DHC_ENG/SitePages/Writing-guidelines.aspx)
+
+[^1]: For example, if you are building on published specs -- such HL7 FHIR.

--- a/doc/organising-your-solution/provide-a-readme-file.md
+++ b/doc/organising-your-solution/provide-a-readme-file.md
@@ -1,0 +1,25 @@
+# Provide a readme file (,/<rootfoldername\>/readme.md)
+
+You **SHOULD** provide a README file in the root folder as a common way
+of helping others learn about your software.
+
+As a minimum, it **SHOULD** instruct others on how to build and deploy
+your software. Typically, you **SHOULD** also include guidelines on how
+to contribute to your project -- how to fix bugs or correct typos, for
+example.
+
+!!! tip "Practical tips"
+    - Use [Microsoft's Writing Style Guide](https://docs.microsoft.com/en-gb/style-guide/welcome/) to maintain a consistent and familiar style
+
+    - Using Markdown makes it easier to format text and include links & images
+
+    - Describe your assurance processes (such as code reviews or gated check-ins) in a separate CONTRIBUTING.md file, saved to the root folder
+
+    - Consider your audience. What would others find useful?
+
+!!! info "Further reading and information"
+    [Create a readme for your Git repo - Azure Repos \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/repos/git/create-a-readme?view=azure-devops)
+
+    [About READMEs - GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)
+
+    [Welcome - Microsoft Style Guide \| Microsoft Learn](https://learn.microsoft.com/en-gb/style-guide/welcome/)

--- a/doc/organising-your-solution/provide-a-scripts-folder.md
+++ b/doc/organising-your-solution/provide-a-scripts-folder.md
@@ -1,0 +1,30 @@
+# Provide a scripts folder (.*/<rootfoldername\>/*build/scripts)
+
+You **SHOULD** store any scripts needed to assist with the build[^1], by
+placing them in a '*scripts'* subfolder. This offers a standard location
+for any others wishing to build your solution.
+
+As well as build scripts, use the folder to store artefacts related to
+your continuous integration (CI) processes. While some CI systems
+require you place build artefacts in the root, placing other supporting
+files in the scripts folder avoids excessive cluttering.
+
+When storing scripts, you **SHOULD** keep your scripts clean and with
+comments.
+
+You **SHOULD** prefer using scripted solutions over build events
+whenever possible.
+
+You **SHOULD NOT** break published conventions without considering how
+this impacts others.
+
+!!! example "Examples of good practice"
+    > {IMAGE PLACEHOLDER}
+    Figure 3 An example.NET Solution with a build and scripts folder
+
+!!! info "Further reading and information"
+    [.NET Core Opinion #4 - Increase Productivity with Dev Scripts (odetocod e.com)](https://odetocode.com/blogs/scott/archive/2018/09/21/net-core-opinion-4-ndash-increase-productivity-with-dev.aspx)
+
+    [.NET Core Opinion #5 - Deployment Scripts and Templates (odet ocode.com)](https://odetocode.com/blogs/scott/archive/2018/10/17/net-core-opinion-5-deployment-scripts-and-templates.aspx)
+
+[^1]: .*exe, .ps1 .sql* and .*cmd* files for example.

--- a/doc/organising-your-solution/provide-a-test-folder.md
+++ b/doc/organising-your-solution/provide-a-test-folder.md
@@ -1,0 +1,28 @@
+# Provide a test folder (.*/<rootfoldername\>/*specs*/*test)
+
+As the name suggests, this is where you **SHOULD** store your tests. As
+with the *src* folder, you **SHOULD** place test projects in sub
+folders, mapping the name of the sub folder to the name of the project.
+
+Names **SHOULD** correspond to those of your dependency layers, with the
+*.Tests* suffix added.
+
+When writing the tests, you **SHOULD:-**
+
+- Prioritise output testing over testing that assures modules.
+
+- Adopt Behavioural Driven Development as your approach.
+
+- Balance the benefits and drawbacks of adding extensive testing to
+    your solution.
+
+- Consider You Aren't Gonna Need It (YAGNI) rules when deciding what
+    to test.
+
+- Consider the testing requirements described in your Definition of
+    Done (DOD).
+
+Consider wider assurance needs when deciding what tests to write. Integration and smoke tests often provide the greatest benefit Consider You Aren't Gonna Need It (YAGNI) and carefully balance the time and effort of an extensive testing approach with the benefit it provides
+
+!!! info "Further reading and information"
+    [Selective Unit Testing -- Costs and Benefits (stevensanderson.com)](http://blog.stevensanderson.com/2009/11/04/selective-unit-testing-costs-and-benefits/)

--- a/doc/organising-your-solution/provide-an-examples-folder.md
+++ b/doc/organising-your-solution/provide-an-examples-folder.md
@@ -1,0 +1,22 @@
+# Provide an examples folder (./<*rootfoldername\>/*examples)
+
+It is **RECOMMENDED** that you provide examples to show others how to
+use your published outputs. Developers will thank you for it!
+
+SQL outputs, scripted languages, or configurations such as yaml, will
+likely be single files. For complex outputs, store each demo project in
+its own sub-folder.
+
+When doing so you **SHOULD:**
+
+- Make sure examples work as expected.
+
+- Demonstrate typical use cases, capabilities and support queries.
+
+- Consider using automation for each example output.
+
+You **SHOULD NOT** let examples become stale and out-of-date.
+
+!!! example "Examples of good practice"
+    > {IMAGE PLACEHOLDER}
+    Figure 4 An example.NET Solution with example

--- a/doc/organising-your-solution/use-additional-sub-folders-for-dependency-layers.md
+++ b/doc/organising-your-solution/use-additional-sub-folders-for-dependency-layers.md
@@ -1,0 +1,29 @@
+# Use additional sub-folders for dependency layers (/src/<dependencylayer\>)
+
+You **SHOULD** create immediate sub-folders to separate the dependency
+layers of your solution, such as data access, user interface, domain
+logic or service layers. This reminds you that the layers exist and to
+test them.
+
+Including the parent's name in the sub folder name may appear
+repetitive, but it adds context. And it can prove useful when
+referencing it from another location or when searching for a file or
+folder.
+
+We leave naming the sub folders underneath ***src*** and **test** to
+your discretion but you **SHOULD :-**
+
+- use Pascal casing when naming folders.
+
+- Follow [Microsoft's naming advice](https://docs.microsoft.com/en-gb/windows/desktop/fileio/naming-a-file)
+    when developing for Windows systems.
+
+You **SHOULD NOT** use special characters or abbreviations longer than
+two letters in folder names.
+
+!!! example "Examples of good practice"
+    > {IMAGE PLACEHOLDER}
+    Figure 1 An example.NET Solution with dependency layers
+
+!!! info "Further reading and information"
+    [Naming Files, Paths, and Namespaces - Win32 apps \| Microsoft Learn](https://learn.microsoft.com/en-gb/windows/win32/fileio/naming-a-file)

--- a/doc/organising-your-solution/use-existing-conventions-for-project-types.md
+++ b/doc/organising-your-solution/use-existing-conventions-for-project-types.md
@@ -1,0 +1,10 @@
+# Use existing conventions for project types
+
+Some project types require you to work with a different convention.
+Typically, these include web projects, MVC, web forms, APIs, or razor
+pages. For example, MVC structures projects for path conventions,
+whereas razor pages use folder hierarchy.
+
+However, the project type determines this - not the software team. And
+you **SHOULD** follow the namespace convention described above for any
+additional folders you add to these project types.

--- a/doc/organising-your-solution/use-physical-folders.md
+++ b/doc/organising-your-solution/use-physical-folders.md
@@ -1,0 +1,10 @@
+# Use physical folders
+
+Typically, a legacy .NET application relies on visual studio solution
+folders. These virtual folders don't represent the physical structure on
+disk.
+
+With no folders to look at, the reader is reliant on our understanding
+of the project names without opening the solution. To overcome this, you
+**SHOULD** follow our first convention and use physical folders and folder
+names.

--- a/doc/organising-your-solution/use-sub-folders-within-visual-studio-projects.md
+++ b/doc/organising-your-solution/use-sub-folders-within-visual-studio-projects.md
@@ -1,0 +1,11 @@
+# Use sub-folders within visual studio projects
+
+You **SHOULD** use sub-folders within each project to reflect
+namespacing and separate dependency layers. Doing so helps remind you
+that the solution is becoming more complex as this tree grows. And
+proves useful when refactoring or extending the project.
+
+You **SHOULD** use parent names in solution subfolder names.
+
+!!! tip "Practical tips"
+    Follow SOLID principles to refactor out exposed complexities. This helps to reduce each project to its simplest form.

--- a/doc/restful-api-standards/api-gateway-pattern.md
+++ b/doc/restful-api-standards/api-gateway-pattern.md
@@ -1,0 +1,9 @@
+# API gateway pattern
+
+APIs **SHOULD** be deployed behind a gateway. This ensures that the
+security policies provided by the gateway are used rather than
+implementing them directly in your back-end API.
+
+Typically, deploy to Apigee or your own API gateway if building APIs
+exclusively for your app. Consult the API platform and Cyber Security
+teams for further advice.

--- a/doc/restful-api-standards/api-management.md
+++ b/doc/restful-api-standards/api-management.md
@@ -1,0 +1,214 @@
+# API management
+
+## Generating an API proxy
+
+To publish an API, generate a proxy from your [Open API
+specification](open-api-specification.md) early in the development
+process. Contact the platform team (see their process map below) for
+details.
+
+## Ping and service status
+
+APIs **SHOULD** implement ping and status endpoints that return an HTTP
+200 OK response. These endpoints allow the platform team to connect the
+API platform to them.
+
+## API lifecycle
+
+The stability of your API and the support you provide depend on its
+[lifecycle status](appendix-a-classifications.md). You **MUST** classify your API
+using the [lifecycle status](appendix-a-classifications.md) definitions described in
+Appendix A.
+
+### Deprecation and retirement
+
+You **MAY** deprecate and retire an API endpoint if it is:
+
+- Replaced by a new endpoint that provides equivalent or enhanced
+    capabilities.
+
+- Not fit for purpose, for example it is insecure.
+
+- Unused or of limited usage.
+
+### Retirement timeline
+
+At the end of the deprecation period, the API endpoints reach
+end-of-life and are taken out of service. At this point, the API
+endpoint **MUST** no longer be available for use.
+
+### Deprecation policy
+
+To deprecate an API endpoint you **MUST**:
+
+- Add a deprecation notice to your documentation stating the
+    deprecation date.
+
+- Add a deprecation header with the deprecation date.
+
+- Email subscribed users with the deprecation date - as the date
+    approaches, emails **SHOULD** be sent more frequently.
+
+- Keep the endpoint available for use and maintain normal service
+    levels.
+
+- Permit no further integrations, although you **MAY** allow consumers
+    in the latter stages of onboarding to complete sign-up.
+
+You **SHOULD** make no further updates unless necessary.
+
+### Retirement policy
+
+To retire an API endpoint, you **MUST**:
+
+- Add a retirement notice to your documentation stating the retirement
+    date, giving no less than **6 months'** notice.
+
+- Add a sunset header with the retirement date.
+
+- Provide a migration guide where applicable.
+
+- Keep the endpoint available for use and maintain normal service
+    levels.
+
+- Permit no further integrations.
+
+You **SHOULD** make no further updates unless necessary.
+
+!!! info "Further reading and information"
+    [RFC 8594 - The Sunset HTTP Header Field](https://datatracker.ietf.org/doc/html/rfc8594)
+
+## Deployment
+
+API deployment **SHOULD** follow DevOps best practices and use
+continuous integration and deployment (CI/CD). For more information see
+our coding standards.
+
+!!! info "Further reading and information"
+    [Software development handbook](../software-development-handbook/introduction.md)
+
+    [Using Source Control](../using-source-control/introduction.md)
+
+!!! tip "Practical tips"
+    **API Platform Starter Project**
+
+    Developers can use the platform team's SDK --that comes with pre-set ping and status policies and ready-made pipelines. These pipelines automatically package your API proxy and deploy it to Apigee once approved.
+
+## Versioning
+
+### Semantic versioning
+
+APIs **MUST** follow the Semantic Versioning Specification 2.0.0. It
+helps API consumers avoid using new versions with breaking changes. You
+**SHOULD** avoid breaking changes where possible.
+
+If you never apply a *breaking change*, simply use semantic versioning
+to differentiate *minor* releases (with added functionality) from
+*patch* releases.
+
+!!! info "Further reading and information"
+    [Semantic Versioning 2.0.0 \| Semantic Versioning](https://semver.org/)
+
+### Versioning urls for release versions
+
+You **MUST** indicate *release* versions with *breaking changes* by
+adding a higher *major version number*, preceded by a lowercase *v* to
+the URL. Exclude version 1.x.x. and *minor* and *patch* version numbers.
+
+!!! example "Examples of good practice"
+    ```sh
+        /{base}/patients
+
+        {*base}*/v2/patients
+
+        /{base}/v1/patients
+
+        /{base}/v2.1.3/patients
+    ```
+
+### Versioning urls for pre-release versions (alpha and beta)
+
+Follow the same method for pre-release versions but include versions 0
+and 1 and add the pre-release type (i.e. *alpha* or *beta*), preceded by
+a dash.
+
+Semantic versioning states that major version 0 is always pre-release;
+therefore alpha/beta labels are not necessarily needed but they help
+clarify API status. Here are some examples:
+
+Version "0.1.3-alpha" published for pre-release testing to:
+
+!!! example "Examples of good practice"
+    `/{base}/v0-alpha/patients`
+
+And then version "1.0.0" published to:
+
+!!! example "Examples of good practice"
+    `/{base}/patients`
+
+Followed by version "1.1.0-beta" published for pre-release testing to:
+
+!!! example "Examples of good practice"
+    `/{base}/v1.1-beta/patients`
+
+Finally, release version "1.1.0" (with no breaking changes) published to
+the original URL:
+
+!!! example "Examples of good practice"
+    `/{base}/patients`
+
+!!! tip "Practical tips"
+    When deploying breaking changes to *beta* versions (i.e. versions used by early adopters), increment the minor version and notify users who might be affected.
+
+## Cataloguing
+
+You **MUST** publish any release version *Open* API to the NHS Wales API
+external product catalogue.
+
+You **MAY** publish an *Open* API, not yet marked as a release, version
+to the NHS Wales API external product catalogue.
+
+You **SHOULD** publish a release version *inner* API to DHCW's internal
+product catalogue.
+
+You **MAY** publish an *inner* API, not yet marked as a release version,
+to DHCW's internal product catalogue.
+
+The catalogue entry **MUST** include the [lifecycle
+status](appendix-a-classifications.md). This makes it clear to consumers where each
+version of your API is in its lifecycle.
+
+!!! tip "Practical tips"
+    Uncatalogued APIs run the risk of being forgotten and not monitored or protected by security tools. See also the [OWASP TOP 10](owasp-top-10.md) section.
+
+## Auditing, tracing and monitoring
+
+If your API deals with [confidential or sensitive data](appendix-a-classifications.md), you
+**MUST** maintain a log that records details about access.
+
+This log **SHOULD** be sent to our Security information and event
+management system (SIEM) and National Intelligent Integrated Audit
+Solution (NIIAS) via an [API gateway](api-gateway-pattern.md).
+
+To ensure compliance and for guidance on the log format and the minimum
+standard fields, consult with the platform team or Cyber security team.
+
+!!! info "Further reading and information"
+    [National Intelligent Integrated Audit Solution (NIIAS) - Home](https://nhswales365.sharepoint.com/sites/DHC_IGNI)
+
+## Rate limiting and throttling
+
+All APIs **SHOULD** set client usage quotas and rate limits. For
+critical systems, this is a **MUST**. Speak to the platform team and
+Cyber Security team for help.
+
+### Spike arrests
+
+The platform team will help you handle sudden traffic spikes and keep
+you API stable. Rate limiting, a key feature in Apigee, sets thresholds
+on the number of requests within a specific period.
+
+This ensures a controlled flow of traffic, preventing overloads and
+optimising performance. No manual configuration is required; the API
+platform team oversees Apigee, guaranteeing effective rate limiting for
+a reliable and responsive API experience.

--- a/doc/restful-api-standards/appendix-a-classifications.md
+++ b/doc/restful-api-standards/appendix-a-classifications.md
@@ -1,0 +1,71 @@
+# Appendix A: Classifications
+
+## API type
+
+| **TYPE** | **DEFINITION** |
+| --- | --- |
+| Open | Open APIs are made available to both internal developers within DHCW and external consumers. They are exposed and managed on DHCW's API management platform, Apigee and published on an external catalogue. Examples include *Medicines & Allergies*, *PIX and PDQ APIs* |
+| Internal | Internal APIs are accessible only to internal developers within DHCW. They are, typically, exposed and managed on DHCW's API management platform, Apigee and published on an internal catalogue. They are not intended for external use. |
+| Client specific | These APIs are restricted to a specific client or team within DHCW. They are usually managed independently through that team's own API management tool. They are not typically published on a central catalogue. |
+
+## Data type
+
+| **TYPE** | **DEFINITION** |
+| --- | --- |
+| Public | Access restrictions are not required for read-only access. Examples: NHS Wales Data Dictionary items, dummy data in a public test environment. |
+| Business confidential | Access restrictions are set by organisational policy, contracts, or license agreements, but not by law. Examples: SNOMED CT, internal URLs, and connection strings. |
+| Sensitive | Access restrictions are more stringent and set by laws (e.g. GDPR legislation) Examples: "Personal" data types, as defined in the *Data Protection Impact Assessment Form Template*. |
+| Highly sensitive | Access restrictions are specific to the data items and higher than sensitive or business confidential. Examples: "Special category" and "Higher sensitivity" data types, as defined in the *Data Protection Impact Assessment Form Template*. Examples: database passwords, private encryption keys. |
+
+!!! info "Further reading and information"
+    IG-TEM-1 Data Protection Impact Assessment Form Template
+
+## Network routing type
+
+| **TYPE** | **DEFINITION** |
+| --- | --- |
+| Internal | Data stays within NHS Wales Wide Area Network (WAN). |
+| Peered | Data stays within Health and Social Care Network (HSCN), Public Sector Broadband Aggregation (PSBA), or another secured link (VPN or mTLS) to NHS Wales WAN. |
+| Internet | Data travels across the public internet. |
+
+## Client type
+
+Take care to apply these classifications in context. For example, a
+client may be *pre-authorized* to write patient prescription data but
+only *licenced* for use in reading patient test results.
+
+| **TYPE** | **DEFINITION** |
+| --- | --- |
+| Pre-authorised | Authorised to process the data and apply appropriate access controls for end users. Typically, an application managed by an NHS Wales organisation or a contracted supplier. Authorisation requires formal assurance by an NHS Wales assurance group. Examples: Welsh Clinical Portal, GP Systems, Clinical Workstation. |
+| Licenced | Licenced ('*Trusted')* to process the data if authorised end users supply or grant access to it. Typically, an application procured or under trial usage by an NHS Wales organisation. Licencing for use may require formal assurance by an NHS Wales assurance group. |
+| Open | Has no formal NHS Wales approval or contract licencing its use to process the data. Typically, an application procured, developed, or otherwise obtained by the user. Examples: Postman, SOAP UI |
+
+## Client authentication level
+
+| **LEVEL** | **DEFINITION** |
+| --- | --- |
+| 0: No Authentication | No authentication. |
+| 1: API Key | API Key is provided with each request. *Weak security as the key is both ID and the credential*. |
+| 2: Credentials | Basic client credentials (Client ID and Client Secret) are provided with each request. *More secure as the secret can be omitted when the Client ID is written to audit logs.* |
+| 3: : Access token (using Credentials) | A time limited access token is first obtained in an initial request, then provided with each further request. To obtain the access token the client supplies basic credentials (Client ID and Client Secret). *More secure as credentials are shared less frequently and only with the token endpoint.* Licenced clients may use level 3. |
+
+## Service level
+
+| **LEVEL** | **DEFINITION** |
+| --- | --- |
+| Critical | As defined in *DHCW-POL-5 Service Level Target Policy*, extended downtime is highly disruptive. |
+| Standard | As defined in *DHCW-POL-5 Service Level Target Policy*, e.g. reporting and analytical systems. |
+
+!!! info "Further reading and information"
+    DHCW-POL-5 Service Level Target Policy
+
+## Lifecycle status
+
+| **STATUS** | **DEFINITION** | **RELEASE VERSION** |
+| --- | --- | --- |
+| **Alpha** | Pre-release version and subject to *breaking changes*. Intended to be used only by those involved with the development. **SHOULD** not be available in a production environment. | No |
+| **Beta** | Pre-release version and subject to *breaking changes*. Stable enough for use by early adopters to help you identify bugs and potential improvements. **MAY** be available in a production environment. | No |
+| **Stable** | Release version. You **MUST NOT** introduce breaking changes. Breaking changes **MUST** result in a new major version. **SHOULD** be available in a production environment. | Yes |
+| **Legacy** | The same as *stable*, available for use but no new integrations given it's planned for *deprecation.* **SHOULD** be available in a production environment for existing users. | Yes |
+| **Deprecated** | The same as *stable*, but existing users should switch to a newer version or alternative API. Not intended for new users, given it's planned for *retirement*. **SHOULD** be available in a production environment until retirement. | Yes |
+| **Retired** | No longer supported. APIs move into this category when all users have moved to a newer version or no longer subscribe. **MUST** not be available in any environments. | No |

--- a/doc/restful-api-standards/authentication-and-authorisation.md
+++ b/doc/restful-api-standards/authentication-and-authorisation.md
@@ -1,0 +1,128 @@
+# Authentication and authorisation
+
+The server **SHOULD** enforce authentication and authorisation using
+OAuth 2.0 and OIDC protocols as described below. Typically the API
+Platform team will provide this service.
+
+## Client authentication
+
+Authentication is enforced at one of the following levels.
+
+| **LEVEL** | **DESCRIPTION** |
+| --- | --- |
+| 0 | No Authentication |
+| 1 | API Key |
+| 2 | Credentials |
+| 3 | Access token (using Credentials) |
+| 4 | Access token (using Public Key Cryptography) |
+
+Authentication Levels
+
+The server **MUST** enforce the minimum required level as determined by
+the type of data accessed, client characteristics and network routing:
+
+|  |  | [**DATA TYPE**](appendix-a-classifications.md) |  |  |  |  |
+| --- | --- | --- | --- | --- | --- | --- |
+| [**CLIENT TYPE**](appendix-a-classifications.md) | [**NETWORK ROUTING TYPE**](appendix-a-classifications.md) | **PUBLIC (READ)** | **PUBLIC (WRITE)** | **BUSINESS CONFIDENTIAL** | **SENSITIVE** | **HIGHLY SENSITIVE** |
+| Pre-Authorised | Internal | 0 | 1 | 2 | 2 | 2 |
+|  | Peered | 0 | 1 | 3 | 3 | 3 |
+|  | Internet | 1 | 1 | 3 | 4 | 4 |
+| Licenced | All | 1 | 3 + End User Delegation | 3 + End User Delegation | 4 + End User Delegation | 4 + End User Delegation |
+| Open | All | 1 | 3 + End User Delegation | 3 + End User Delegation | *No access* | *No access* |
+
+Minimum Authentication Levels
+
+## End user delegation
+
+*Licenced* and *Open* clients requesting any access beyond reading
+[public data](appendix-a-classifications.md) **MUST** require users to delegate
+permissions. Users **MUST** be authenticated by the NHS Wales Identity
+Provider.
+
+The server **MUST** implement [role-based access
+controls](authentication-and-authorisation.md) to verify that end users
+are authorised to grant the requested permissions to the client
+application.
+
+## Role-based access control (scopes)
+
+APIs **SHOULD** define access controls as *scopes*. Speak to the
+platform team for further help.
+
+!!! info "Further reading and information"
+    [App Launch: Scopes and Launch Context - SMART App Launch v2.2.0](https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html#scopes-for-requesting-fhir-resources)
+
+## Authorisation grants
+
+For client authentication level 3 without End User Delegation, the
+**RECOMMENDED** method is to use the OAuth 2.0 grant type
+client_credentials to obtain a bearer token, as described in RFC 6749,
+section 4.4.
+
+For client authentication level 3 with End User Delegation, the
+**RECOMMENDED** method is to use the OAuth 2.0 grant type
+authorization_code to obtain a token. The client **MUST** use client_id
+and client_secret to authenticate with the token endpoint, as described
+in RFC 6749, sections 4.1 and 2.3.1.
+
+For level 4 client authentication without End User Delegation, the
+**RECOMMENDED** method is to use the OAuth 2.0 grant type
+urn:ietf:params:oauth:grant-type:jwt-bearer, as described in RFC 7523,
+section 2.1.
+
+For level 4 client authentication with End User Delegation, the
+**RECOMMENDED** method is to use the OAuth 2.0 grant type
+authorization_code to obtain a token. The client **MUST** use a client
+assertion to authenticate with the token endpoint, as described in RFC
+7523, section 2.2.
+
+!!! info "Further reading and information"
+    [RFC 6749 - The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+
+    [RFC 7523 - JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants](https://datatracker.ietf.org/doc/html/rfc7523)
+
+## Access token expiry
+
+When using authentication level 3 or above, access tokens **MUST**
+expire within the following time frames:
+
+- For [Business Confidential data](appendix-a-classifications.md): within 1 day.
+
+- For [Sensitive data](appendix-a-classifications.md): within 1 hour.
+
+- For [Highly Sensitive data](appendix-a-classifications.md): tokens **SHOULD** expire
+    within 5 minutes but **MUST** expire within 1 hour.
+
+## Restrictions on data use
+
+| **ENVIRONMENT** | **RESTRICTIONS ON DATA SENT TO AND FROM AN API** |
+| --- | --- |
+| Development | Data **SHOULD** be classified as "[Public](appendix-a-classifications.md)" (e.g., synthetic test data[^1]) Data **MUST NOT** be classified as "[Sensitive](appendix-a-classifications.md)" or "[Highly Sensitive](appendix-a-classifications.md)" Data **MUST NOT** be written to systems in Production |
+| Sandbox | Data **MUST** be classified as "[Public](appendix-a-classifications.md)" (e.g., synthetic test data) |
+| Systems Integration Testing | Data **SHOULD** be classified as "[Public](appendix-a-classifications.md)" (e.g., synthetic test data) Data **MUST NOT** be classified as "[Sensitive](appendix-a-classifications.md)" or "Highly Sensitive" Data **MUST NOT** be written to systems in Production |
+| User Acceptance Testing | Data **MUST NOT** be written to systems in Production |
+| Production | No restrictions apply; however, please refer to the [API Security standards](security-headers.md). |
+
+## Input validation
+
+The server **MUST** validate all inputs to prevent code injection,
+cross-site scripting (XSS) attacks and other malicious requests such as
+overposting and mass assignment.
+
+The server **SHOULD** restrict query parameter string filters to
+enumerated values or regular expressions.
+
+## Browser-based access and Cross-Origin Resource Sharing (CORS)
+
+APIs **MUST NOT** be accessed directly from code running in a browser
+unless they are limited to reading or writing public data.
+
+If the server permits direct browser access then:
+
+- The outbound HTTP header Access-Control-Allow-Origin **MUST** be set
+    to a specific value and **MUST NOT** be a wildcard.
+
+- The inbound HTTP header Origin **MUST** be validated against a list
+    of permitted host names for authenticated applications.
+
+[^1]: Note Synthetic data should be useful and reflect the use-case of the API

--- a/doc/restful-api-standards/compound-collection-operations.md
+++ b/doc/restful-api-standards/compound-collection-operations.md
@@ -1,0 +1,13 @@
+# Compound collection operations
+
+When paging, filtering & sorting operations are performed together, the
+evaluation order **MUST** be:
+
+1. **Filtering:** All filtering expressions, including range queries,
+    **MUST** be applied using an AND operation.
+
+2. **Sorting:** The filtered list **MUST** be sorted according to the
+    specified sort criteria.
+
+3. **Paging:** The sorted, filtered list **MUST** then be paged. This
+    applies to both token-based and client-driven paging.

--- a/doc/restful-api-standards/concurrency-control.md
+++ b/doc/restful-api-standards/concurrency-control.md
@@ -1,0 +1,32 @@
+# Concurrency control
+
+To prevent accidental overwrites of updates, design your concurrency
+control model carefully to handle transient faults appropriately.
+
+The server **SHOULD** ensure that clients include an If-Match header
+when making changes to resources that might be updated concurrently.
+
+When a client sends an If-Match header with a valid ETag value:
+
+- The server **MUST** check if the provided ETag matches the current
+    ETag of the resource.
+
+- If they match, the server processes the request and returns a 2xx
+    HTTP status code (for example, 200 OK) indicating success.
+
+- If they do not match, the server **MUST** return a 412 PRECONDITION
+    FAILED status code to indicate a conflict.
+
+If a client does not include the If-Match header:
+
+- The server **MUST** respond with a 428 PRECONDITION **REQUIRED** HTTP
+    status code, indicating that the If-Match header is required.
+
+- The response **MUST** include a clear message instructing clients to
+    include the If-Match header in future requests for the resource.
+
+You **MUST** describe in your API documentation which resources require
+the use of the If-Match header.
+
+!!! info "Further reading and information"
+    [Testing for lost updates](../testing-lost-updates/introduction.md)

--- a/doc/restful-api-standards/data-classification.md
+++ b/doc/restful-api-standards/data-classification.md
@@ -1,0 +1,12 @@
+# Data classification
+
+You **MUST** classify resource data types according to the platform
+team's data classification framework (see [Appendix
+A](appendix-a-classifications.md)).
+
+Based on the classification, you **MUST** apply the appropriate security
+controls.
+
+For detailed guidance on implementing security measures, refer to the
+[Authentication and Authorisation](authentication-and-authorisation.md)
+section.

--- a/doc/restful-api-standards/definitions.md
+++ b/doc/restful-api-standards/definitions.md
@@ -1,0 +1,20 @@
+# Definitions
+
+| **TERM(S)** | **DEFINITION** |
+| --- | --- |
+| API / Server / Resource server | A server-side API, including API gateways acting as reverse proxies. Categorised as *Open, internal* or *client specific*. See [Appendix A](appendix-a-classifications.md). |
+| API Consumer team / Consumer | Individuals or teams integrating APIs into client applications. Typically developers or software professionals. |
+| API Platform team / Platform team | Manages Apigee tools and standards, simplifying API implementation. |
+| API Producer team | Develops backend APIs. Teams can be internal or third-party. |
+| Authorisation grant | Credential representing the end user's authorisation of a client to access API resources. |
+| Breaking change | An update that causes existing dependent code to fail or behave unexpectedly. |
+| Calling Application / Client / Client application | A software application making API requests. Clients may be *Public* (e.g. Single Page Applications) or *Confidential* (e.g. server-side web applications). |
+| End User / Resource owner / User | The user who controls access to specific API resources. |
+| End User Delegation / Delegation | Allows users to grant clients permission to access API resources. |
+| Endpoint | The URL or URI representing a unique API resource. |
+| FHIR Profile | Defines constraints, extensions, and specific use cases for FHIR resources tailored for healthcare systems or domains. |
+| Namespace | A group of related endpoints providing specific functionality or hierarchy, ensuring clarity and avoiding naming conflicts. |
+| NHS Wales Identity Provider | Secure Token Service issuing OAuth and OpenID Connect tokens for authentication and authorisation. |
+| Proxy | Middleware enhancing security, analytics, and API management, acting as a gateway to backend APIs. |
+| Resource(s) / resource model(s) | Data fields representing objects, accessible via unique URLs or endpoints, forming the API's core. |
+| Service / System | A system exposing one or more API endpoints. Sometimes used interchangeably with Namespace. |

--- a/doc/restful-api-standards/documentation.md
+++ b/doc/restful-api-standards/documentation.md
@@ -1,0 +1,228 @@
+# Documentation
+
+Good documentation makes our APIs easier to use. Even without a
+technical writer, this guide shows you how to create clear,
+well-structured API docs.
+
+!!! info "Further reading and information"
+    [Documenting APIs - GOV.UK](https://www.gov.uk/guidance/how-to-document-apis)
+
+    [Documenting APIs: A guide for technical writers and engineers](https://idratherbewriting.com/learnapidoc/)
+
+## Writing style
+
+You **SHOULD** follow DHCW's Writing checklist, ensuring that you:
+
+- Write short sentences.
+
+- Talk directly to your user by using 'you' and active verbs.
+
+- Use the active voice and plain language.
+
+- Avoid using 'home-grown' terms that are not industry standard.
+
+!!! info "Further reading and information"
+    [DHCW Writing checklist](https://nhswales365.sharepoint.com/sites/DHCW-Intranet/SitePages/Writing-style-guide.aspx)
+
+## OpenAPI specification
+
+You **SHOULD**:
+
+- Describe your API using the OpenAPI (OAS) definition, version 3. OAS
+    is a global standard for describing RESTful APIs in a human and
+    machine-readable format.
+
+- Provide OpenAPI definitions in YAML, as described in the next
+    section.
+
+- Add a monitored email address to the info object of the OpenAPI
+    definition to allow consumers to contact you with issues or
+    comments.
+
+- Include the full semantic version number in the info object of the
+    OpenAPI definition.\
+    Store your OpenAPI specification in source control and keep it up to
+    date.
+
+!!! info "Further reading and information"
+    [Semantic Versioning 2.0.0 \| Semantic Versioning](https://semver.org/)
+
+## Document structure
+
+You **SHOULD** organise your API documentation. This section provides a
+**RECOMMENDED** structure:
+
+!!! example "Examples of good practice"
+    ```sh
+        ├── system.yml
+        ├── {api-id}/
+        │   ├── api.yml
+        │   ├── spec/
+        │   │   ├── open-api.yml or service.wsdl
+        │   │   └── example-requests/
+        │   └── user-guide/
+        │       └── (see the user-guide section for more information)
+    ```
+
+### System.yml
+
+`system.yml` describes the underlying service that exposes the API
+endpoints. Information that might otherwise be repeated across related
+APIs can be added to the description. It contains the following fields:
+
+| **FIELD** | **MAX CHARACTERS** | **DESCRIPTION** |
+| --- | --- | --- |
+| `short-name` | 10 | Name or abbreviation to be used as a prefix when displayed in the API catalogue. |
+| `description` | 150 | What the service does. |
+
+### Api.yml
+
+`api.yml` provides a brief overview of:
+
+- What your API does.
+
+- Whether your API is in the alpha, beta or in production.
+
+- Who can use your API, and any restrictions on using it or its data.
+
+| **FIELD** | **MAX CHARACTERS** | **DESCRIPTION** |
+| --- | --- | --- |
+| `title` | 80 | Name or abbreviation to be used as a prefix when displayed in the API catalogue. |
+| `description` | 150 | What the service does. |
+| `overview` | 800 | Provide brief details for each of the following: - ***What the API does***: A more detailed description with specifics about data sources and formats. - ***Who will use it and why***: Provide examples of typical consumers and why they would use the API. - ***Where it's available***: Mention any restrictions on use. |
+| `owner` | 30 | Email address for main point of contact for information about the API. |
+| `type` | N/A | `FHIR`, `REST` `SOAP`, `HL7v2`, `HL7v3` `Solr` or `GraphQL` |
+| `status` | N/A | `Alpha`, `Beta` `Stable`, `Legacy`, `Deprecated` or `Retired` |
+| `data type` | N/A | `Public`, `Business Confidential` `Sensitive` or `Highly Sensitive` |
+
+### Spec/open-api.yml
+
+Include an `open-api.yml` file in the `spec` folder. You **SHOULD** format
+descriptions in markdown so that the platform team can generate HTML
+documentation in the API [catalogue](api-management.md).
+
+You **SHOULD NOT** include the actual endpoint of your API server.
+Replace it with *<https://private.url>*.
+
+You **MAY** include examples in the `open-api.yml` file.
+
+### Spec/service.wsdl
+
+If you are publishing a legacy SOAP service, you **SHOULD** provide a
+service.wsdl document in the spec/example-requests folder. Contact the
+platform team for more information.
+
+### User-guide
+
+Although documentation can be auto generated from the `open-api.yml` or
+`service.wsdl`, you **MAY** enhance it by adding a user guide as markdown
+files.
+
+!!! example "Examples of good practice"
+    ```sh
+        user-guide/
+        ├── overview.md
+        ├── quickstart.md
+        ├── how-to/
+        │   ├── 1-{description}.md
+        │   └── n-{description}.md
+        ├── concepts/
+        │   ├── {concept}.md
+        │   └── {concept}.md
+    ```
+
+### Overview.md -- introduce your API
+
+You **SHOULD** start with a brief overview that explains what the API
+does and how it works. Focus on technical details suitable for
+developers and emphasise any prerequisites or essential concepts.
+
+!!! example "Examples of good practice"
+    *'A FHIR API that lets you retrieve ValueSets resources of SNOMED concepts.'*
+
+    *//...how it works*
+
+    *'A SOAP API that triggers a questionnaire to be sent.'*
+
+    *//...how it works*
+
+### Quickstart.md - how to get started
+
+You **SHOULD** create a concise section that guides users through the
+quickest and simplest method of obtaining an example response from your
+API. Assume the reader is familiar with the necessary technology but
+highlight any advanced or unconventional steps, including potential
+pitfalls or important considerations.
+
+### How-to -- task-based guides for common scenarios
+
+You **SHOULD** provide task-based examples in a user-friendly style to
+help users with common integration tasks. Write them in the same style
+as the quickstart; however, these examples can be longer and more
+complex. Examples **SHOULD** have the following characteristics:
+
+- Begin with a front-loaded title that starts with a verb.
+
+- Focus on helping users complete one task.
+
+- Tell users what they need to do, not how the system works.
+
+- Use numbered steps for clarity.
+
+- Include example code and descriptions for request parameters and
+    response fields.
+
+- Provide links to any subsequent tasks the user needs to complete.
+
+!!! example "Examples of good practice"
+    *'**Retrieve ValueSets resources of SNOMED concepts** -- using a FHIR API'*
+
+    *'**Trigger the sending of a questionnaire** -- using a SOAP API'*
+
+!!! tip "Practical tips"
+    Avoid duplicating basic info about the API. Link to the Getting started
+    section instead.
+
+### Concepts
+
+You **SHOULD** explain any essential concepts, such as document metadata
+standards. If a concept refers to an external source you **SHOULD**
+provide a link.
+
+### Error response codes
+
+You **SHOULD** place error responses near the endpoint documentation or
+at the end of the API reference. Even if you anticipate only standard
+responses, such as 400 NOT FOUND or 200 OK, you **MUST** clarify how
+they relate to your API.
+
+!!! tip "Practical tips"
+    - Store the OpenAPI definition in the docs folder of your code repository.
+
+    - Create custom tasks in your CI/CD pipeline to publish API documentation to Apigee.
+
+## Developer portal
+
+We provide two developer portals for managing and publishing APIs:
+
+| **FEATURE** | **DESCRIPTION** | **URL** |
+| --- | --- | --- |
+| Internal Developer Portal | Allows developers to browse the internal API catalogue, obtain API keys, and test APIs before external publication. | <https://apim-apigee-test-nhswales.apigee.io/> |
+| External Developer Portal | Central hub for publishing and managing API documentation. Provides a user-friendly interface for API consumers. | [Home - NHS Wales Digital Platform](https://digitalplatform.nhs.wales/) |
+
+When you are ready to publish your API documentation, contact the
+platform team for guidance.
+
+## Software development kits (sdks)
+
+Creating a client-side SDK takes effort, but it can simplify integration
+for your users. If you provide an SDK with your API, you **MUST** test it
+thoroughly to ensure reliability.
+
+!!! tip "Practical tips"
+    Understand your users' needs. A .NET client might not be useful to a Java developer!
+
+## Exceptions
+
+Standards provide valuable guidance, but there may be rare exceptions.
+Principal and Lead Software Developers have discretion in such cases.

--- a/doc/restful-api-standards/encryption.md
+++ b/doc/restful-api-standards/encryption.md
@@ -1,0 +1,18 @@
+# Encryption
+
+The server **MUST** secure communications using at least TLS 1.2
+(https).
+
+The server **SHOULD**:
+
+- Use one of the TLS cipher suites recommended in *SOP-OSD-001
+    Encryption in Transit* and *SS-OSD-006 Application Programming
+    Interfaces (APIs)*
+
+- Use a TLS certificate signed by a chain ending with a trusted
+    Certificate Authority (CA)
+
+!!! info "Further reading and information"
+    SOP-OSD-001 Encryption in Transit
+
+    SS-OSD-006 Application Programming Interfaces (APIs)

--- a/doc/restful-api-standards/error-reporting.md
+++ b/doc/restful-api-standards/error-reporting.md
@@ -1,0 +1,29 @@
+# Error reporting
+
+[HTTP status codes](http-implementation.md) often provide sufficient
+error information. But sometimes the client needs additional details.
+
+If your APIs follow the FHIR standard, the server **MUST** return the
+OperationOutcome resource.
+
+For non-FHIR APIs, the server **SHOULD** follow RFC7807 or, where
+applicable, the JSON API specification.
+
+When returning error information, the server **MUST NOT** include
+unnecessary or sensitive data that attackers could exploit. See also the
+[OWASP 10](owasp-top-10.md) & [Minimise Information
+Disclosure](security-headers.md) sections.
+
+The server **MUST** use [HTTP status codes](http-implementation.md)
+in the 5xx range to indicate server errors. For client errors, the
+server **SHOULD** return a 4xx status code.
+
+!!! tip "Practical tips"
+    ASP.NET Core's ProblemDetails formats errors according to RFC7807.
+
+!!! info "Further reading and information"
+    [OperationOutcome - FHIR v4.0.1](https://hl7.org/fhir/R4/operationoutcome.html#operationoutcome)
+
+    [RFC 7807 - Problem Details for HTTP APIs](https://datatracker.ietf.org/doc/html/rfc7807)
+
+    [JSON:API --- A specification for building APIs in JSON](https://jsonapi.org/)

--- a/doc/restful-api-standards/essential-good-practice-checklist.md
+++ b/doc/restful-api-standards/essential-good-practice-checklist.md
@@ -1,0 +1,29 @@
+# Essential good practice checklist
+
+| **No.** | **Checklist Item** |  | **Section Heading** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 1 | APIs conform to FHIR R4. | ☐ | FHIR (Fast Healthcare Interoperability Standards) | Suitable FHIR R4 p rofiles may be unava ilable. |
+| 2 | You have identified the resource data type. | ☐ | Data Classification |  |
+| 3 | You have an OpenAPI specification kept in source control. | ☐ | OpenAPI Specification |  |
+| 4 | You structure API endpoints for predictability. | ☐ | URL Structure |  |
+| 5 | You use HTTP verbs to define operations. | ☐ | HTTP Implementation |  |
+| 6 | APIs return correct HTTP status codes. | ☐ |  |  |
+| 7 | You follow FHIR or our JSON payload rules and structure. | ☐ | Payload Rules JSON Response Payload Structure | Unless following the FHIR specification |
+| 8 | You apply Paging to collections with an unbounded number of items. | ☐ | Paging |  |
+| 9 | You return errors in a common format. | ☐ | Error Reporting |  |
+| 1 0 | You publish a transient fault contract.. | ☐ | Handling Transient Faults |  |
+| 1 1 | You follow naming conventions and use standard query parameters. | ☐ | Naming |  |
+| 1 2 | You define a maximum response time. | ☐ | Performance and Response Times |  |
+| 1 3 | You deploy APIs to an API gateway. | ☐ | API Management |  |
+| 1 4 | API clients authenticate using OAuth and OIDC. | ☐ | Authentication and Authorisation |  |
+| 1 5 | You apply the correct restrictions on data usage. | ☐ | Restrictions on Data Use |  |
+| **No.** | **Checklist Item** |  | **Guide or standard** | **Exceptions** |
+| 1 6 | APIs implement *ping* and service status endpoints. | ☐ | Ping and Service Status |  |
+| 1 7 | You follow our deprecation and retirement policies. | ☐ | Deployment |  |
+| 1 8 | API use semantic versioning. | ☐ | Versioning |  |
+| 1 9 | You publish APIs to an API catalogue. | ☐ | Cataloguing |  |
+| 2 0 | You monitor APIs and apply rate limits where appropriate. | ☐ | Auditing, Tracing and Monitoring |  |
+| 2 1 | You deploy API using CI / CD pipelines to an API gateway. | ☐ | Deployment |  |
+| 2 2 | You write Test reports for every major, minor and patch version of your API. | ☐ | Test Summary Report |  |
+| 2 3 | Test reports include security testing and code coverage metrics. | ☐ |  |  |
+| 2 4 | You follow our documentation recommendations. | ☐ | Documentation |  |

--- a/doc/restful-api-standards/fhir-fast-healthcare-interoperability-standards.md
+++ b/doc/restful-api-standards/fhir-fast-healthcare-interoperability-standards.md
@@ -1,0 +1,12 @@
+# FHIR (fast healthcare interoperability standards)
+
+APIs **MUST** conform to the FHIR R4 specification when a relevant FHIR
+profile exists. Where no suitable profile is available, you may need to
+model custom resources following FHIR principles.
+
+FHIR R4 already addresses many fundamental aspects of RESTful API
+design. If your API implementation is based on FHIR, you can jump
+directly to the [Security](security-headers.md) section.
+
+!!! info "Further reading and information"
+    [Wales FHIR Implementation Guide](https://simplifier.net/guide/fhir-standards-wales-implementation-guide?version=1.0.0)

--- a/doc/restful-api-standards/filtering.md
+++ b/doc/restful-api-standards/filtering.md
@@ -1,0 +1,136 @@
+# Filtering
+
+## Field selection
+
+Endpoints **SHOULD** return a default set of fields, but the server
+**MAY** allow clients to customise the response, using the `fields` query
+parameter. This helps avoid retrieving unnecessary data.
+
+However the server **MUST** always return mandatory fields specified in
+the model schema, even if not requested. For example the `conditions`
+field is returned even if not specified in the query.
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients/9991234566?fields=NHSNumber,firstName,lastName
+        // 200 OK
+
+        Content-Type: application/json; charset=utf-8
+        {
+            "patient": {
+                "NHSNumber": "9991234566",
+                "firstName": "Humphrey",
+                "lastName":  "Appleby ",
+                "conditions": [
+                    {
+                        "id": "1",
+                        "name": "Hypertension"
+                    }
+                ]
+            }
+        }
+    ```
+
+## Simple filtering
+
+The server **MAY** allow clients to search specific fields by specifying
+the field name in the query.
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients?lastName=Appleby&fields=NHSNumber,firstName,lastName
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        {
+            "patients": [
+            {
+                "NHSNumber": "9991234566",
+                "firstName": "Humphrey",
+                "lastName": "Appleby",
+                "conditions": [
+                    {
+                        "id": "1",
+                        "name": "Hypertension"
+                    },
+                    {
+                        "id": "2",
+                        "name": "Diabetes"
+                    }
+                ]
+            },
+            {
+                "NHSNumber": "9991234599",
+                "firstName": "Lady",
+                "lastName": "Appleby",
+                "conditions": [
+                    {
+                        "id": "1",
+                        "name": "Hypertension"
+                    }
+                ]
+            }]
+        }
+    ```
+
+The server **MAY** allow clients to combine search parameters and filter
+by relational fields. This allows for advanced searches across related
+data.
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients?lastName=Appleby& expand=conditions&condition.name=diabetes
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        {
+            "patients": [
+            {
+                "NHSNumber": "9991234566",
+                "firstName": "Humphrey",
+                "lastName": "Appleby",
+                "conditions": [
+                    {
+                        "id": "1",
+                        "name": "Hypertension"
+                    },
+                    {
+                        "id": "2",
+                        "name": "Diabetes"
+                    }
+                ]
+            }
+        ]
+        }
+    ```
+
+## Advanced filtering
+
+To enable more advanced filtering logic, the server **MAY** support
+OData 4.0-compliant query parameters. These allow clients to specify
+filtering expressions that are evaluated for each resource in the
+collection, including only items where the expression evaluates to
+*true*.
+
+The following operators **MUST** be supported with the *filter* query:
+
+| **OPERATOR GROUP** | **OPERATOR** | **DESCRIPTION** |
+| --- | --- | --- |
+| **COMPARISON** | `eq` | Equal |
+|  | `ne` | Not equal |
+|  | `gt` | Greater than |
+|  | `ge` | Greater than or equal |
+|  | `lt` | Less than |
+|  | `le` | Less than or equal |
+| **LOGICAL** | `and` | Logical and |
+|  | `or` | Logical or |
+|  | `not` | Logical negation |
+| **GROUPING** | `()` | Precedence grouping |
+
+!!! example "Examples of good practice"
+    GET *{base}*/patients?filter=lastName eq Appleby and age ge 53
+
+## Elasticsearch and lucene
+
+When using Elasticsearch, Lucene, or equivalent search products, the
+server **SHOULD** align with the syntax of the chosen product.
+Alternatively, consider using well-documented, standardised mechanisms
+such as OData filter syntax or a GraphQL service.

--- a/doc/restful-api-standards/general-principles.md
+++ b/doc/restful-api-standards/general-principles.md
@@ -1,0 +1,34 @@
+# General principles
+
+The following principles guide these standards:
+
+- Prioritise user needs.
+
+- Treat APIs as products, with dedicated teams, lifecycles, and
+    roadmaps.
+
+- Make APIs the primary interface for system interactions.
+
+- Build APIs that are easy to learn, use, reuse, and integrate.
+
+- Enable portability with container technologies like Docker.
+
+- Adopt DevOps practices to deliver continuous value.
+
+- Build APIs that conform to HL7 FHIR as a foundational interoperability standard.
+
+- Use REST as the default design style, although you **MAY** choose alternatives when justified.
+
+!!! tip "Practical tips"
+    Appoint a dedicated API Product Owner to prioritise user needs.
+
+!!! info "Further reading and information"
+    The API Strategy & Roadmap
+
+    [HL7 FHIR as a foundational standard in all NHS Wales Bodies \| GOV.WALES](https://www.gov.wales/introduction-hl7-fhir-foundational-standard-all-nhs-wales-bodies-whc2023018)
+
+    [Fielding Dissertation: CHAPTER 5: Representational State Transfer (REST) (uci.edu)](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm)
+
+    [The API Product Mindset (google.com)](https://cloud.google.com/files/apigee/apigee-api-product-mindset-ebook.pdf)
+
+    [The principles --- Good Services ](https://good.services/15-principles-of-good-service-design)

--- a/doc/restful-api-standards/handling-transient-faults.md
+++ b/doc/restful-api-standards/handling-transient-faults.md
@@ -1,0 +1,55 @@
+# Handling transient faults
+
+APIs **MUST** be designed to handle transient faults caused by temporary
+network issues, timeouts, or service disruptions. Clients **SHOULD**
+implement retry strategies to maintain reliability without overwhelming
+the system.
+
+## Identifying transient faults
+
+The API **MUST** clearly define transient faults and distinguish them
+from permanent failures.
+
+The API **MUST** specify which [HTTP status
+codes](http-implementation.md) indicate transient faults that are
+safe to retry:
+
+- 5xx errors (e.g. 500 Internal Server Error) indicate server-side
+    faults.
+
+- Some 4xx errors **MAY** also be transient and safe to retry, such as:
+
+  - 429 Too Many Requests (after respecting Retry-After).
+
+  - 408 Request Timeout, if caused by temporary network issues.
+
+  - 409 Conflict, if due to a temporary resource state.
+
+## Retry strategies
+
+Clients **MUST** ensure retries do not introduce unintended side
+effects. APIs **MUST** be *idempotent* where possible.
+
+If an API returns Retry-After, clients **MUST** wait before retrying.
+
+Clients **SHOULD** use *exponential backoff* with *jitter* to avoid
+spikes in retry traffic.
+
+The API **SHOULD** document:
+
+- The *maximum number of retry attempts* before a failure is
+    considered permanent.
+
+- *Recommended wait times* between retries.
+
+- *Rate limits* to avoid excessive retries.
+
+Additional **RECOMMENDATIONS**:
+
+- APIs **SHOULD** use *circuit breakers* to prevent repeated calls
+    when a service remains unavailable.
+
+- Clients **SHOULD** *randomise retries* to prevent simultaneous retry bursts.
+
+- If the API is deployed on Apigee, it **MUST** integrate with
+    Apigee's transient fault handling features.

--- a/doc/restful-api-standards/http-implementation.md
+++ b/doc/restful-api-standards/http-implementation.md
@@ -1,0 +1,221 @@
+# HTTP implementation
+
+APIs **MUST** follow standard HTTP semantics to ensure consistency,
+predictability and interoperability. This section outlines good
+practice, but refer to official specs when needed:
+
+!!! info "Further reading and information"
+    [RFC 9110: HTTP Semantics - Status Codes (rfc-editor.org)](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes)
+
+    [API design best practices - Conform to HTTP semantics \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/architecture/best-practices/api-design#conform-to-http-semantics)
+
+## Hypermedia (hateos)
+
+A RESTful API **MUST** implement *Hypermedia as the Engine of
+Application State (HATEOAS)* to be classified as *Richardson Level 3*.
+HATEOAS allows clients to navigate and manipulate resources dynamically
+without requiring prior knowledge of specific URIs.
+
+However, *HATEOAS* is NOT required for APIs in this organisation.
+But if implemented:
+
+- The API **MUST** provide hypermedia links to guide clients on
+    available actions.
+
+- These links **SHOULD** use standard link relations where possible
+    (e.g. as defined in RFC 8288) and **MUST** be documented in the
+    API's OpenAPI definition.
+
+!!! info "Further reading and information"
+    [RFC 8288: Web Linking](https://www.rfc-editor.org/rfc/rfc8288.html)
+
+## HTTP verbs and resource operations
+
+APIs **MUST** use standard HTTP methods correctly to ensure predictable
+behaviour.
+
+- APIs **MUST** only expose necessary HTTP methods and **MUST**
+    document them in the [OpenAPI definition](documentation.md).
+
+- APIs **SHOULD** return `405 Method Not Allowed` for unsupported HTTP
+    methods instead of silently ignoring them.
+
+- APIs **MUST** adhere to the standard HTTP semantics defined in *RFC 9110*,
+    including idempotency rules.
+
+- Non-standard HTTP verbs **MUST NOT** be used.
+
+!!! info "Further reading and information"
+    [RFC 9110: HTTP Semantics - Status Codes (rfc-editor.org)](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes)
+
+## Standard HTTP methods and usage
+
+| **OPERATION** | **HTTP VERB** | **PATH** | **REQUEST BODY** | **RESPONSE BODY** | **IDEMPOTENT** |
+| --- | --- | --- | --- | --- | --- |
+| **LIST** | `GET` | `/resources` | None | Collection Resource | ✅ Yes |
+| **RETRIEVE** | `GET` | `/resources/{id}` | None | Resource | ✅ Yes |
+| **CREATE** | `POST` | `/resources` | Resource | Resource | ❌ No |
+| **REPLACE** | `PUT` | `/resources/{id}` | Resource | Resource | ✅ Yes |
+| **MODIFY** | `PATCH` | `/resources/{id}` | Partial Resource | Resource | ❌ No |
+| **DELETE** | `DELETE` | `/resources/{id}` | None | None | ✅ Yes |
+| **RETRIEVE HEADERS** | `HEAD` | `/resources/{id}` | None | None | ✅ Yes |
+| **QUERY CAPABILITIES** | `OPTIONS` | `/resources` | None | Allowed Methods | ✅ Yes |
+
+- `GET`, `HEAD`, `OPTIONS`, and `DELETE` **MUST NOT** modify resources.
+
+- `PUT` and `DELETE` **MUST** be idempotent to ensure safe retries.
+
+- `PATCH` is `NOT` idempotent unless explicitly designed to be.
+
+- `POST` **MUST** be used for non-idempotent operations such as resource
+    creation.
+
+## HTTP request headers
+
+PIs **MUST** support and handle the following request headers:
+
+| **HEADER** | **DESCRIPTION** |
+| --- | --- |
+| `Authorization` | Used for authentication. APIs **MUST** validate this header and reject malformed requests. |
+| `Content-Type` | **MUST** be included in requests with a body. Allowed values: *`application/json`, `application/xml`, `multipart/form-data`, `application/x-www-form-urlencoded`*. |
+| `Date` | **MUST** be formatted as per RFC 5322, e.g. Tue, *11 Oct 2022 09:27:30 GMT.* |
+
+!!! info "Further reading and information"
+    [RFC 5322 - Internet Message Format](https://datatracker.ietf.org/doc/html/rfc5322)
+
+APIs **SHOULD** support the following request headers:
+
+| **HEADER** | **DESCRIPTION** |
+| --- | --- |
+| `Accept` | Specifies the response format. Default: *`application/json`*. |
+| `Access-Control-Request-Method` | Used in CORS preflight requests to indicate the intended HTTP method. |
+
+APIs **MAY** support additional request headers:
+
+| **HEADER** | **DESCRIPTION** |
+| --- | --- |
+| `x-api-key` | A legacy authentication method. **MAY** be used only when legacy support is required. Prefer Authorization |
+| `X-Audit-Consent` | JSON-encoded FHIR consent resource (base64, max 8KB). |
+| `X-Audit-Device` | FHIR identifier for the client device (base64, max 8KB). |
+| `X-Au dit-Organisation` | FHIR identifier for the client organisation (base64, max 8KB). |
+| `X-Audit-User` | FHIR identifier for the authenticated user (base64, max 8KB). |
+| `X-Au thenticated_User` | Identifies the client system for auditing. |
+| `Cache-Control` | Controls caching (e.g. *`no-store`*). |
+| `Connection` | Manages connection behaviour (e.g. *`keep-alive`*). |
+| `If-Match`, `If-None-Match` | Used for optimistic concurrency control with resource updates. |
+| `Origin` | If present, APIs **MUST** validate it against a list of allowed origins to ensure security. |
+| `X-Request-Id` | A unique identifier for the API request. If not provided by the client, this identifier **MAY** be generated in the API Gateway. |
+
+## HTTP response headers
+
+APIs **SHOULD** return the following response headers:
+
+| **HEADER** | **DESCRIPTION** |
+| --- | --- |
+| `Cache-Control` | Controls caching (e.g. *`no-store` or `private, max-age=3600`*). |
+| `Content-Security-Policy` | Defines security policies to mitigate XSS and injection (e.g. *`frame-ancestors 'none'`*). |
+| `Content-Type` | Specifies the response media type (e.g. *`application/json` or `application/xml`*). Used only if a message body is returned. |
+| `Location` | On successful resource creation Post, the API **MUST** return a `201 CREATED` status and a Location header with the new resource's relative URL. |
+| `Request-Id` | Echoes the unique request identifier provided by the client. |
+| `Strict-Transport-Security` | Enforces HTTPS (e.g. *`max-age=31536000; includeSubDomains`*). |
+| `WWW-Authenticate` | Specifies the required authentication method (e.g. *`Bearer realm="nhswales365", authorization_uri="..."`*). |
+| `X-Content-Type-Options` | Prevents MIME sniffing (e.g. *`nosniff`*). |
+| `X-Frame-Options` | Prevents clickjacking (e.g. *`SAMEORIGIN` or `DENY`*). |
+
+The following optional response headers **MAY** apply:
+
+| **HEADER** | **DESCRIPTION** |
+| --- | --- |
+| `Access-Control-Allow-Origin` | Specifies allowed origins for web access. If used, the value **MUST** be non-wildcard (i.e., *not \**). |
+| `Content-Security-Policy` | Restricts content sources (e.g. *`default-src 'none'`*). |
+| `Date` | Response timestamp in RFC 5322 format (e.g. *`Tue, 11 Oct 2022 09:27:31 GMT`*). |
+| `ETag` | Indicates the resource version. Used with `If-Match` / `If-None-Match` for optimistic concurrency control. |
+| `Expires` | The date/time after which the response is considered stale (RFC 5322 format). |
+| `Feature-Policy` | Defines permitted client-side features (e.g. *`none`*). |
+| `Referrer-Policy` | Specifies the level of referrer information to include (e.g. *`no-referrer`*). |
+| `Retry-After` | Indicates when a client should retry a failed request (expressed in seconds or as a date - RFC 5322 format. RFC 5322 is **RECOMMENDED**. |
+
+!!! tip "Practical tips"
+    Additional headers **MAY** be added or modified by the API gateway
+    to [deprecate or retire](api-management.md) an API or apply
+    [rate limiting](api-management.md), for example. Speak to the platform
+    team for more help.
+
+!!! info "Further reading and information"
+    [RFC 5322 - Internet Message Format](https://datatracker.ietf.org/doc/html/rfc5322)
+
+## Return HTTP status codes
+
+The server **MUST** return the correct HTTP status code for each API
+operation, as per RFC 9110. The table below lists common status codes,
+but others **MAY** be used if needed.
+
+- "✅ Yes" means the status code applies to that operation.
+
+- An empty cell means the code is not usually used for that operation.
+
+| **HTTP STATUS CODE** | **GET (COLLECTION)** | **GET (RESOURCE)** | **POST (COLLECTION)** | **PUT (RESOURCE)** | **PATCH (RESOURCE)** | **DELETE (RESOURCE)** |
+| --- | --- | --- | --- | --- | --- | --- |
+| `200 OK`                     | ✅ Yes | ✅ Yes |  | ✅ Yes | See caveats below |  |
+| `201 CREATED`                |  |  | ✅ Yes |  |  |  |
+| `202 ACCEPTED`               |  |  | ✅ Yes | ✅ Yes | ✅ Yes | ✅ |
+| `304 NOT MODIFIED`           | See caveats below |  |  |  |  |  |
+| `400 BAD REQUEST`            | ✅ Yes | ✅ Yes |         |        |         |        |
+| `401 UNAUTHORIZED`           | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| `403 FORBIDDEN`              | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| `404 NOT FOUND`              | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| `405 METHOD NOT ALLOWED`     | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| `408 REQUEST TIMEOUT`        | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| `409 CONFLICT`               |  |  | ✅ Yes | ✅ Yes |  |  |
+| `412 PRECONDITION FAILED`    |  |  | ✅ Yes | ✅ Yes | ✅ Yes | See caveats below |
+| `415 UNSUPPORTED MEDIA TYPE` | ✅ Yes | ✅ Yes | ✅ Yes | ✅ | Yes | ✅ Yes |
+| `422 UNPROCESSABLE ENTITY`   |  |  | ✅ Yes | ✅ Yes | ✅ Yes |  |
+| `428 PRECONDITIONS` **REQUIRED** |  |  | ✅ Yes | ✅ Yes | ✅ Yes | See caveats below |
+| `429 TOO MANY REQUESTS`      | See caveats below |  |  |  |  |  |
+| `500 INTERNAL SERVER ERROR`  | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| `501 NOT IMPLEMENTED`        | See caveats below |  |  | ✅ Yes | ✅ Yes |  |
+| `502 BAD GATEWAY`            | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| `503 SERVICE UNAVAILABLE`    | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| `504 GATEWAY TIMEOUT`        | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+
+### Caveats and edge cases
+
+- While `PATCH` can return 200 `OK` with the updated resource, 202
+    `ACCEPTED` is preferred for asynchronous processing. But some
+    implementations **MAY** choose to return `200 OK` instead.
+
+- `304 NOT MODIFIED` applies only when the API supports caching with
+    conditional GET requests. The server **MAY** return `304 NOT MODIFIED`
+    if the client's cached version is still valid.
+
+- Use `409 CONFLICT`when there's a conflict with the current state of
+    the target resource. Use `422 UNPROCESSABLE ENTITY` when the server
+    understands the request but can't process it due to semantic
+    errors.
+
+- Use `409 CONFLICT`when there's a conflict with the current state of
+    the target resource. Use `422 UNPROCESSABLE ENTITY` when the server
+    understands the request but can't process it due to semantic
+    errors.
+
+- While `415 UNSUPPORTED MEDIA TYPE` is typically used for `POST`, `PUT` and
+    `PATCH`, it **MAY** apply to `GET` if a body is sent with an unsupported
+    media type --- although this is rare.
+
+- `412 PRECONDITION FAILED` and `428 PRECONDITIONS` **REQUIRED** are typically
+    used for `POST`, `PUT` and `PATCH`. However, some designs **MAY** also
+    apply them to `DELETE` if preconditions are enforced.
+
+- Use `428 PRECONDITIONS` **REQUIRED** when the server requires the request to
+    be conditional, typically to prevent the "lost update" problem. Use
+   `412 PRECONDITION FAILED` when a precondition specified in the request
+   isn't met.
+
+- Typically our API platform will apply rate limiting and return
+    `429 TOO MANY REQUESTS` when appropriate.
+
+- Some designs **MAY** extend the use of `501 NOT IMPLEMENTED` to other
+    methods if a particular method is not supported by the server.
+
+!!! info "Further reading and information"
+    [RFC 9110: HTTP Semantics - Status Codes (rfc-editor.org)](https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes)

--- a/doc/restful-api-standards/http-message-caching.md
+++ b/doc/restful-api-standards/http-message-caching.md
@@ -1,0 +1,6 @@
+# HTTP message caching
+
+Typically, you **SHOULD NOT** allow sensitive data, returned over an
+authenticated (HTTPS) connection, to be cached. But if you do, you
+**MUST** make sure there is no risk that network appliances cache data
+in clear text. Speak to the Cyber security team for help.

--- a/doc/restful-api-standards/introduction.md
+++ b/doc/restful-api-standards/introduction.md
@@ -1,0 +1,95 @@
+# Introduction
+
+## Purpose
+
+These standards:
+
+- Specify the requirements for designing and building RESTful APIs.
+
+- Provide guidance for aligning with our API Strategy & Roadmap.
+
+They are intended for API producers but may also assist teams
+integrating APIs into client applications.
+
+!!! tip "Practical tips"
+    If you have production APIs, you need not introduce breaking changes solely to comply. Contact the author for support.
+
+!!! info "Further reading and information"
+    The API Strategy & Roadmap
+
+## Scope
+
+### In-scope
+
+These standards apply to RESTful APIs designed and built for:
+
+- Internal use within the organisation.
+
+- External use by clients, partners, or third parties.
+
+A [good practice checklist](essential-good-practice-checklist.md) is also
+included to assist teams in achieving compliance.
+
+### Out-of-scope
+
+These standards do not apply to:
+
+- Non-RESTful APIs, including GraphQL, gRPC, and event-driven APIs
+    (e.g. Azure Functions).
+
+- APIs designed primarily to handle large binary data (e.g. image or
+    file delivery).
+
+- Topics outside API design and implementation, such as Domain-driven
+    design or microservices architecture.
+
+- Infrastructure, networking, or Web Application Firewalls (WAF).
+
+- API publishing pipelines (e.g. via Apigee).
+
+- Telemetry, monitoring, or general software development practices.
+
+## References
+
+1. The API Strategy and Roadmap
+1. [Software development handbook](../software-development-handbook/introduction.md)
+1. [Testing for lost updates](../testing-lost-updates/introduction.md)
+1. [How to write a Test Summary Report](../test-summary-report/introduction.md)
+1. SDS-TEM-5 - Test Summary Report template
+1. [Using Source Control](../using-source-control/introduction.md)
+1. [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+1. [General Coding Standards](../general-coding-standards/introduction.md)
+1. IG-TEM-1 - Data Protection Impact Assessment Form Template
+1. DHCW-POL-5 - Service Level Target Policy
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions. If a hyperlink is missing, search for the document in our Document Management System.
+
+## The need for guidance
+
+Conforming to these standards helps you build APIs that are consistent,
+easy to use, safe and secure.
+
+!!! tip "Practical tips"
+    **Integration as a 'war of attrition'**
+
+    Read about Mark Wardle's experience integrating applications with NHS Wales systems. Mark is a Consultant Neurologist and Chair of the Welsh Technical Standards Board.
+
+!!! info "Further reading and information"
+    [wardle/concierge: README \> Background](https://github.com/wardle/concierge#readme)

--- a/doc/restful-api-standards/json-response-payload-structure.md
+++ b/doc/restful-api-standards/json-response-payload-structure.md
@@ -1,0 +1,313 @@
+# JSON response payload structure
+
+## Response format
+
+JSON response payloads **SHOULD** adhere to the following structure:
+
+```json
+    ├── meta (Object, 0..1)
+    ├── data (Object, 0..1)
+    ├── links (Object, 0..1)
+    │         ├── href (String, 1..1)
+    │         └── rel (String, 1..1)
+    └── errors (Object, 0..1)
+            ├── type (String, 1..1)
+            ├── title (String, 1..1)
+            ├── status (Number, 1..1)
+            ├── detail (String, 1..1)
+            ├── instance (String, 0..1)
+            └── invalidParams (Array, 0..1)
+```
+
+| **ELEMENT** | **TYPE** | **CARDINALITY** | **DESCRIPTION** |
+| --- | --- | --- | --- |
+| meta | Object | 0..1 | Contains metadata (e.g. pagination details such as offset, pageOffset, pageSize, total) |
+| data | Object | 0..1 | Contains the primary resource or a resource collection. When returning a single resource, you **MAY** place the resource directly inside data without nesting. |
+| links | Object | 0..1 | Provides links to related resources or partial results. **SHOULD** only identify resources in the same versioned Namespace. |
+| errors | Object | 0..1 | Contains error details as per *RFC 7807*. If present no other top-level objects should be returned.. |
+| href | String | 1..1 | The URL to a nested resource or the next set of items. |
+| rel | String | 1..1 | Relation value. Use a standard Link Relation Type if available. |
+| type | 1..1 | String | URL to the API's error documentation. |
+| title | 1..1 | String | A short, human-readable summary of the error. |
+| status | 1..1 | Number | Status code (e.g. 400 BAD REQUEST). |
+| detail | 1..1 | String | Detailed error description for troubleshooting. |
+| instance | 0..1 | String | URL or path to the resource that caused the error. |
+| invalidParams | 0..1 | Array | Array of objects specifying invalid parameters and reasons. |
+
+## Get operation on an individual resource
+
+For a GET operation on an individual resource, the response **SHOULD**
+enclose the primary resource within a data object. The outer property
+name uses the singular form of the resource name.
+
+Direct:
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients/9991234566
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        {
+            "data": {
+                "NHSNumber": "9991234566",
+                "firstName": "Humphrey",
+                "lastName": "Appleby"
+            }
+        }
+    ```
+
+Nested:
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients/9991234566
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        {
+            "data": {
+                "patient": {
+                "NHSNumber": "9991234566",
+                "firstName": "Humphrey",
+                "lastName": "Appleby",
+                // ... other patient details ...
+                }
+            }
+        }
+    ```
+
+## Get operation on a collection of resources
+
+For a collection of resources, the response **SHOULD** enclose the
+resource collection within a data object, using the plural form of the
+resource name.
+
+A collection with 0 items **SHOULD** return HTTP 200 OK rather than 404
+NOT FOUND
+
+Non-empty collection example:
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        {
+            "data": {
+                "patients": [
+                {
+                    "NHSNumber": "9991234566",
+                    "firstName": "Humphrey",
+                    "lastName": "Appleby",
+                    // ... other patient details ...
+                },
+                {
+                    "NHSNumber": "9991234567",
+                    "firstName": "Jim",
+                    "lastName": "Hacker",
+                    // ... other patient details ...
+                },
+                // ... more patients ...
+                ]
+            }
+        }
+    ```
+
+Empty collection - valid example:
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        {
+            "data": []
+        }
+    ```
+
+Empty collection - invalid example:
+
+!!! danger "Examples of practices to avoid"
+    ```json
+        GET /{base}/patients
+        // 404 NOT FOUND
+        Content-Type: application/json; charset=utf-8
+        {
+            "data": []
+        }
+    ```
+
+## Get operation on nested resources
+
+For nested resources, the response **SHOULD** either embed the nested
+resources or provide navigable links in the links object. See also
+[Returning related resources using query
+parameters](retrieving-related-data.md).
+
+Embedded resources example (using the expand parameter):
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients/9991234566?expand=practitioners,conditions
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        {
+            "data": {
+                "patient": {
+                "NHSNumber": "9991234566",
+                "firstName": "Humphrey",
+                "lastName": "Appleby",
+                // ... other patient details ...
+                "practitioner": {
+                    "id": "123",
+                    "name": "Dr. Liz Asher",
+                    // ... other details of the primary care provider ...
+                },
+                "conditions": [
+                    {
+                    "id": "1",
+                    "name": "Hypertension",
+                    // ... other details of the condition ...
+                    },
+                    {
+                    "id": "2",
+                    "name": "Diabetes",
+                    // ... other details of the condition ...
+                    }
+                    // ... more condition records ...
+                ]
+                }
+            }
+        }
+    ```
+
+Linked resources example (using the include parameter):
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients?include=conditions,practitioners
+        // 200 OK
+        {
+            "data": {
+                "patient": {
+                "NHSNumber": "9991234566",
+                "firstName": "Humphrey",
+                "lastName": "Appleby",
+                // ... other patient details ...
+                }
+            },
+            "links": {
+                "practitioner": {
+                "href": "/practitioners/123",
+                "rel": "practitioner",
+                "NHSNumber": "9991234566"
+                },
+                "conditions": [
+                {
+                    "href": "/conditions/1",
+                    "rel": "condition",
+                    "NHSNumber": "9991234566"
+                },
+                {
+                    "href": "/conditions/2",
+                    "rel": "condition",
+                    "NHSNumber": "9991234566"
+                }
+                ]
+            }
+        }
+    ```
+
+!!! info "Further reading and information"
+    [Link Relations (www.iana.org)](https://www.iana.org/assignments/link-relations/link-relations.xhtml)
+
+## Data operations (POST, PUT & PATCH)
+
+For data operations such as POST, PUT, or PATCH, the request **SHOULD**
+include the primary resource data. After a successful POST operation on
+a collection, the server **SHOULD** create and return a unique resource
+identifier.
+
+Example request:
+
+!!! example "Examples of good practice"
+    ```json
+        POST /{base}/patients
+        Host: //some host
+        Content-Type: application/json; charset=utf-8
+        {
+        "data": {
+            "patient": {
+            // ... patient details ...
+            }
+        }
+        }
+    ```
+
+Example response:
+
+!!! example "Examples of good practice"
+    ```json
+        201 Created
+        Location Header: /{base}/patients/{9991234568}
+        Content-Type: application/json; charset=utf-8
+        {
+            "data": {
+                "patient": {
+                "NHSNumber": "9991234568",  // The server-generated unique identifier
+                // ... other patient details ...
+                }
+            }
+        }
+    ```
+
+## Returning an error
+
+When returning an error, the server **SHOULD** follow the *RFC 7807*
+format. This ensures that error information is provided in a consistent
+and standardised manner. See [Error reporting](error-reporting.md) for
+more details.
+
+Example request:
+
+!!! example "Examples of good practice"
+    ```json
+        POST /{base}/patients
+        Host: //some host
+        Content-Type: application/json; charset=utf-8
+        {
+            "data": {
+                "patient": {
+                "NHSNumber": "9991234568",
+                "firstName": "Bernard",
+                "lastName": "Woolley",
+                "dateOfBirth": "1942-01-06",
+                "gender": "Male",
+                // ... other patient details ...
+                }
+            }
+        }
+    ```
+
+Example response:
+
+!!! example "Examples of good practice"
+    ```json
+        HTTP/1.1 400 Bad Request
+        Content-Type: application/problem+json
+        {
+            "type": "https://example.com/errors/id-not-allowed",
+            "title": "ID Not Allowed",
+            "status": 400,
+            "detail": "Resource identifiers (IDs) are managed exclusively by the server",
+            "instance": "/api/patients",
+            "invalidParams": [
+                {
+                "name": "NHSNumber",
+                "reason": "NHSNumber should not be provided in the client request."
+                }
+            ]
+        }
+    ```
+
+!!! info "Further reading and information"
+    [RFC 7807 - Problem Details for HTTP APIs](https://datatracker.ietf.org/doc/html/rfc7807)

--- a/doc/restful-api-standards/naming.md
+++ b/doc/restful-api-standards/naming.md
@@ -1,0 +1,73 @@
+# Naming
+
+## Resource names
+
+Resource names **SHOULD** be clear, descriptive and written in
+*lowerCamelCase*. Use plural nouns in URLs and to identify resource
+collections in JSON payloads. Use the singular form to identify an
+individual resource in a JSON payload.
+
+!!! example "Examples of good practice"
+    `/{base}*/patients/{id*}`
+
+    `/{base}*/Patient/{id*}`
+
+    `/{base}*/getPatient/{id*}`
+
+Prefer nouns to verbs, even if the noun is not immediately obvious.
+
+!!! example "Examples of good practice"
+    `/{base}*/uk-who/calculation`
+
+    `/{base}*/uk-who/calculate`
+
+## Resource identifiers
+
+Resource identifiers **MUST** serve as unique references for resources.
+It is **RECOMMENDED** to use the field name "*id*" or to concatenate
+the resource name with "*Id*" when referencing these identifiers.
+
+Resource identifiers **MUST** be URL safe and not expose implementation
+details such as database primary keys.
+
+## Resource fields
+
+Resource fields **MUST** be descriptive and use *lowerCamelCase*.
+
+!!! example "Examples of good practice"
+    ```json
+        {
+        "data": {
+            "patients": [
+            {
+                "firstName": "Humphrey",
+                // ... other patient details ...
+            },
+                // ... more patients ...
+            ]
+        }
+    }
+    ```
+
+## Query parameters
+
+Query parameters **SHOULD** be written in *lowerCamelCase*.
+
+You **SHOULD NOT** define query parameters with names that differ only
+in case.
+
+The server **SHOULD NOT** be case sensitive when processing query
+parameters.
+
+When query parameters are treated as strings they present an opportunity
+for injection attacks. To minimise risk, the server **SHOULD** constrain
+the values of string filters to enumerations or regular expressions.
+
+## Reserved names
+
+You **SHOULD** adhere to the defined behaviour for query parameters as
+described in this standard. These names are reserved for their intended
+purposes and **MUST NOT** be repurposed.
+
+!!! info "Further reading and information"
+    [Microsoft Graph REST API Guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/graph/GuidelinesGraph.md)

--- a/doc/restful-api-standards/open-api-specification.md
+++ b/doc/restful-api-standards/open-api-specification.md
@@ -1,0 +1,19 @@
+# Open API specification
+
+You **SHOULD** write an OpenAPI specification before generating
+server-side code.
+
+A design-first approach **SHOULD** be used to enable earlier testing and
+validation. However, you **MAY** adopt a code-first approach where it
+better suits the needs of your project. Refer to the
+[Documentation](documentation.md) section for further guidance.
+
+!!! tip "Practical tips"
+    Use the API platform team's Open API template to ensure your API includes required security schemas and essential operations like [Ping and Status](api-management.md).
+
+!!! info "Further reading and information"
+    [OpenAPI Specification - Version 3.1.0 \| Swagger](https://swagger.io/specification/)
+
+    [OpenAPI & .NET: You're Doing It Wrong - Mark Rendle - NDC London 2023](https://www.youtube.com/watch?v=acGvHkl4uto)
+
+    [C# ASP.NET 5 - Designing Web APIs with Swagger aka OpenAPI Specification](https://www.youtube.com/watch?v=l-6cNIVMk6Q)

--- a/doc/restful-api-standards/owasp-top-10.md
+++ b/doc/restful-api-standards/owasp-top-10.md
@@ -1,0 +1,8 @@
+# OWASP top 10
+
+During assurance, you **MUST** provide evidence of adequate mitigations
+against OWASP Top 10 API Security Risks -- 2023 in a Test Summary
+report.
+
+!!! info "Further reading and information"
+    [OWASP Top 10 API Security Risks -- 2023 - OWASP API Security Top 10](https://owasp.org/API-Security/editions/2023/en/0x11-t10/)

--- a/doc/restful-api-standards/paging.md
+++ b/doc/restful-api-standards/paging.md
@@ -1,0 +1,233 @@
+# Paging
+
+When performing a **GET** operation on a collection, the server **MAY**
+return a partial result. The server **SHOULD** apply paging to
+collections with an unbounded number of items.
+
+## Token-based paging (recommended)
+
+Token-based paging, where the server controls the paging sequence, is
+**RECOMMENDED**. Common approaches include cursor, keyset, and seek
+paging.
+
+The server **SHOULD** supply a continuation token in the href field of
+the [navigation link](paging.md) and assign it to a query parameter
+named token. This token **MUST** be an encoded string.
+
+If the client omits the token, the server **MUST** return the first
+partial result, eliminating the need to include a page token in the URL
+of the first link.
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients?pageOffset=2&pageSize=10&total=true
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        {
+        "meta": {
+            "pageOffset": 2,
+            "pageSize": 10,
+            "total": 40
+        },
+        "data": {
+            "pageOffset": 2,
+            "pageSize": 10,
+            "patients": [
+            {
+                "NHSNumber": "9991234566"
+                // ... other patient details ...
+            },
+            {
+                "NHSNumber": "9991234567"
+                // ... other patient details ...
+            }
+            // ... 8 more patient records ...
+            ]
+        },
+        "links": [
+            {
+            "href": "/patients?page=2&pageSize=10",
+            "rel": "self"
+            },
+            {
+            "href": "/patients?page=1&pageSize=10",
+            "rel": "first"
+            },
+            {
+            "href": "/patients?page=1&pageSize=10",
+            "rel": "prev"
+            },
+            {
+            "href": "/patients?page=3&pageSize=10",
+            "rel": "next"
+            },
+            {
+            "href": "/patients?page=4&pageSize=10",
+            "rel": "last"
+            }
+        ]
+        }
+    ```
+
+## Client-driven paging
+
+Allowing clients to control paging provides flexibility but may be less
+efficient. The server **MAY** allow clients to supply an offset (or
+pageOffset) integer value as the starting point.
+
+If omitted, the server **MUST** use default values of offset=0 or
+pageOffset=1. If the value is greater than or equal to the number of
+resources, the server **MUST** return an empty collection.
+
+If the value is invalid, the server **SHOULD** return a 400 BAD REQUEST
+HTTP status code.
+
+The server **SHOULD** include the offset values in the response ---
+whether explicitly provided or not --- to maintain context for the
+client.
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients?pageOffset=2&pageSize=10&total=true
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        {
+        "meta": {
+            "pageOffset": 2,
+            "pageSize": 10,
+            "total": 40
+        },
+        "data": {
+            "pageOffset": 2,
+            "pageSize": 10,
+            "patients": [
+            {
+                "NHSNumber": "9991234566",
+                // ... other patient details ...
+            },
+            {
+                "NHSNumber": "9991234567",
+                // ... other patient details ...
+            }
+            // ... 8 x more patient records ...
+            ]
+        },
+        "links": {
+            "self": {
+            "href": "/patients?page=2&pageSize=10",
+            "rel": "self"
+            },
+            "first": {
+            "href": "/patients?page=1&pageSize=10",
+            "rel": "first"
+            },
+            "prev": {
+            "href": "/patients?page=1&pageSize=10",
+            "rel": "prev"
+            },
+            "next": {
+            "href": "/patients?page=3&pageSize=10",
+            "rel": "next"
+            },
+            "last": {
+            "href": "/patients?page=4&pageSize=10",
+            "rel": "last"
+            }
+        }
+        }
+    ```
+
+## Paging stability
+
+When implementing paging, the server **MUST** ensure the following:
+
+- The server **MUST** sort on a unique value. This may require sorting
+    on an additional value (typically a primary key) if necessary.
+
+- Sorting and filtering parameters **MUST** be consistent across pages
+    to maintain predictability.
+
+- Query options **MUST NOT** be changed while iterating over a partial
+    result set.
+
+(See the sections on [Filtering](filtering.md), [Sorting](sorting.md) and
+[Compound Collections](compound-collection-operations.md) for more
+information.)
+
+## Page links
+
+The server **MUST** indicate a partial result by including navigation
+links as JSON objects within the links array. Each JSON object
+**SHOULD** contain rel and href  fields.
+
+The rel field **SHOULD** be restricted to the following values: self,
+first, prev, next and last.
+
+The absence of a next link indicates that there are no more results.
+
+The absence of a prev link typically indicates the start of the result
+set, although it **MAY** be omitted if reverse paging is expensive or
+impractical.
+
+Similarly, the server **MAY** omit the last link if providing it is
+costly or impractical.
+
+href fields in links **MUST** contain a URL with any appropriate query
+parameters.
+
+## Page size
+
+The server **MAY** allow clients to specify the number of items returned
+using the pageSize query parameter. It **MUST** either use this value or
+apply a default pageSize when none is specified.
+
+The server **MUST** set a default pageSize and an upper limit
+(maxPageSize) for each resource collection. These values **SHOULD** be
+determined based on reasonable estimates of default and maximum request
+times and payload sizes.
+
+Clients **MAY** specify an integer value for pageSize or request the maximum
+allowed by setting pageSize to maxPageSize.
+
+If pageSize is not a non-negative integer or exceeds maxPageSize, the
+server **SHOULD** return a 400 BAD REQUEST HTTP status code.
+
+The server **MAY** return fewer items than specified by the pageSize
+when returning the last page.
+
+The server **SHOULD** include the pageSize value in the links object
+within the response, regardless of whether it was explicitly provided or
+set by default.
+
+## Total
+
+The server **MAY** allow clients to request the total number of matches
+by providing a total query parameter.
+
+If the client specifies total=true, the server **SHOULD** return the
+total number of matches in the total field at the root of the JSON
+response.
+
+By default, the total parameter **MUST** be set to false.
+
+!!! tip "Practical tips"
+    total indicates the overall number of results that match the request, not the number of resources returned in the current response..
+
+## Paging nested resources
+
+The server **MAY** support client paging of nested resources and
+**SHOULD** provide the necessary navigation links for such cases.
+
+## Paging implementation
+
+When implementing paging, the server **SHOULD** consider the following
+key aspects:
+
+- Establish a method for handling updates to maintain data consistency
+    and accuracy.
+
+- Implement efficient data retrieval mechanisms to minimise
+    performance impact.
+
+- Ensure secure encoding of continuation tokens to protect client
+    privacy and data integrity.

--- a/doc/restful-api-standards/payload-rules.md
+++ b/doc/restful-api-standards/payload-rules.md
@@ -1,0 +1,56 @@
+# Payload rules
+
+Some rules in this section align with JSON API, while others differ. You
+**MAY** follow the complete JSON API specification, but you **MUST**
+carefully consider its impact.
+
+## Encoding and content negotiation
+
+For encoding, you **SHOULD** use "UTF-8".
+
+Unicode **MUST** be used as the standard encoding for all text
+representations of dates in APIs, and it is the default for JSON.
+
+The server **SHOULD** represent resources in JSON (RFC 8259/ECMA-404) by
+default, defined as application/json in the OpenAPI specification.
+
+You **MAY** add extra media types, but they **MUST** be described in the
+OpenAPI definition.
+
+If your API can return multiple media types, it **SHOULD** return the
+first supported type indicated in the HTTP Request's Accept header.
+
+If the requested media types are unsupported, the server **SHOULD**
+return an HTTP response with status 415 UNSUPPORTED MEDIA TYPE.
+
+## Date formats
+
+HTTP headers containing datetime values **MUST** use the RFC 5322
+format:
+
+- `ddd, dd MMM yyyy HH:mm:ss Z`
+
+Dates or timestamps in the JSON payload of the response **MUST** conform to
+the RFC 3339 format:
+
+- `YYYY-MM-DDTHH:mm:ssZ`
+
+## Payload size
+
+For performance reasons, the server **SHOULD** use [paging](paging.md) for
+large datasets or binary objects.
+
+The server **SHOULD** keep the total payload size below 2 MB and
+**MUST** ensure that it does not exceed 10 MB, as this is a hard limit
+for some platforms.
+
+!!! info "Further reading and information"
+    [JSON:API --- A specification for building APIs in JSON](https://jsonapi.org/)
+
+    [RFC 8259: The JavaScript Object Notation (JSON) Data Interchange Format](https://www.rfc-editor.org/rfc/rfc8259)
+
+    [ECMA-404 - Ecma International](https://ecma-international.org/publications-and-standards/standards/ecma-404/)
+
+    [RFC 5322 - Internet Message Format](https://datatracker.ietf.org/doc/html/rfc5322)
+
+    [RFC 3339 - Date and Time on the Internet: Timestamps](https://datatracker.ietf.org/doc/html/rfc3339)

--- a/doc/restful-api-standards/performance-and-response-times.md
+++ b/doc/restful-api-standards/performance-and-response-times.md
@@ -1,0 +1,30 @@
+# Performance and response times
+
+You **MUST** define a maximum response time and specify any exceptions.
+
+To improve performance and minimise network traffic, you **SHOULD**
+consider the following options. Your choice depends on your use-case and
+user needs:
+
+- Implement a server-side cache (for example, ASP.NET output caching)
+    or a distributed cache (for example, Redis) for more complex
+    scenarios.
+
+- Allow clients to cache responses (response caching) while taking
+    care to mitigate any potential security risks; see [HTTP Messaging
+    caching](http-message-caching.md).
+
+- Avoid blocking calls. For example, ASP.NET web APIs **SHOULD** use
+    the async keyword.
+
+- Take advantage of [paging](paging.md) and [filtering](filtering.md) to
+    limit the amount of data returned in responses.
+
+- Compress responses and minify JSON payloads.
+
+You **MUST** monitor and analyse API performance and take corrective
+actions if your APIs do not meet the performance thresholds defined in
+your solutions architecture.
+
+!!! info "Further reading and information"
+    [ASP.NET Core Best Practices \| Microsoft Learn](https://learn.microsoft.com/en-gb/aspnet/core/fundamentals/best-practices?view=aspnetcore-7.0)

--- a/doc/restful-api-standards/retrieving-related-data.md
+++ b/doc/restful-api-standards/retrieving-related-data.md
@@ -1,0 +1,59 @@
+# Retrieving related data
+
+## Using separate urls for related resources
+
+Endpoints **SHOULD** return only primary resources by default.
+
+To prevent overloading clients, the server **MAY** offer alternative
+endpoints to fetch related data.
+
+URLs **SHOULD NOT** exceed two levels of nesting to maintain readability
+and usability.
+
+If a resource can be independently accessed without its parent, it
+**SHOULD** have its own top-level endpoint.
+
+!!! example "Examples of good practice"
+    `{base}/appointmentsService/patients`
+
+    `{base}/appointmentsService/patients/{id}`
+
+    `{base}/appointmentsService/patients/{id}/conditions`
+
+    `{base}/appointmentsService/patients/{id}/conditions/{id}`
+
+    `{base}*/appointmentsService/patients/*{id}*/encounters/*{id}*/observations/*{id}`
+
+## Returning related resources using query parameters
+
+The server **MAY** support include and expand query parameters to
+optimise data retrieval.
+
+include **MUST** return navigation links for the specified related
+resources.
+
+expand **MUST** embed related data directly within the response.
+
+!!! example "Examples of good practice"
+    `{base}/appointmentsService/patients/{id}?include=conditions`
+
+    `{base}/appointmentsService/patients/{id}?expand=practitioners,conditions`
+
+Additional **RECOMMENDATIONS**:
+
+- **Separate URLs vs Query Parameters**: Use query parameters only
+    when they add value. For complex data retrieval, consider GraphQL.
+
+- **Balance Performance and Usability**: Overuse of expand can degrade
+    performance, while excessive nesting complicates API navigation.
+
+!!! info "Further reading and information"
+    [REST Modelling: designing a future-friendly AP \| LinkedIn](https://www.linkedin.com/pulse/rest-modeling-designing-future-friendly-api-david-hickey/)
+
+    [Use links, not keys, to represent relationships in APIs \| Google Cloud Blog](https://cloud.google.com/blog/products/application-development/api-design-why-you-should-use-links-not-keys-to-represent-relationships-in-apis)
+
+    [Organise the API design around resources \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/architecture/best-practices/api-design#organize-the-api-design-around-resources)
+
+    [Extraneous Fetching antipattern - Azure Architecture Center \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/architecture/antipatterns/extraneous-fetching/)
+
+    [Chatty I/O antipattern - Performance antipatterns for cloud apps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/architecture/antipatterns/chatty-io/)

--- a/doc/restful-api-standards/secrets-and-certificate-management.md
+++ b/doc/restful-api-standards/secrets-and-certificate-management.md
@@ -1,0 +1,7 @@
+# Secrets and certificate management
+
+You **SHOULD NOT** store secrets in clear-text storage.
+
+Secrets and API keys **MUST** be stored and encrypted in a secrets
+manager. Where secrets are injected from a secrets manager into a CI-CD
+pipeline, they **MUST NOT** be logged.

--- a/doc/restful-api-standards/security-headers.md
+++ b/doc/restful-api-standards/security-headers.md
@@ -1,0 +1,43 @@
+# Security headers
+
+Use [HTTP response headers](http-implementation.md) to specify security
+controls in HTTP communications. These serve as an extra layer of
+protection against common vulnerabilities and privacy risks.
+
+## Minimise information disclosure
+
+You **SHOULD** remove unnecessary HTTP response headers that expose
+details about the server and its underlying technologies. For example,
+consider the following response which includes headers that reveal
+server information:
+
+!!! danger "Examples of practices to avoid"
+    ```sh
+        *HTTP/1.1 201 Created*
+
+        *Content-Type: application/json; charset=utf-8*
+
+        *Location: /api/patients/9991234568*
+
+        *Date: 2024-02-17T12:00:00Z*
+
+        *Server: Microsoft-IIS/10.0*
+
+        *X-AspNet-Version: 6.0.0*
+
+        *X-AspNetMvc-Version: 6.0.0*
+    ```
+
+You **SHOULD** remove these sensitive headers. A valid response might
+look like this:
+
+!!! example "Examples of good practice"
+    ```sh
+        *HTTP/1.1 201 Created*
+
+        *Content-Type: application/json; charset=utf-8*
+
+        *Location: /api/patients/9991234568*
+
+        *Date: 2024-02-17T12:00:00Z*
+    ```

--- a/doc/restful-api-standards/sorting.md
+++ b/doc/restful-api-standards/sorting.md
@@ -1,0 +1,47 @@
+# Sorting
+
+The server **MAY** support sorting of result sets by accepting a
+comma‐separated list of expressions via the sort query parameter. The
+server **SHOULD** honour the client's preferences.
+
+By default the server **SHOULD** sort in ascending order but **MAY**
+sort in descending order if the client prefixes an expression with a
+dash (-).
+
+NULL values **MUST** be treated as less than non-NULL values.
+
+Items **MUST** be sorted according to the order of expressions provided.
+The first expression defines the primary sort order; for items with
+identical values in the first expression, the second expression defines
+the secondary order, and so on.
+
+!!! example "Examples of good practice"
+    ```json
+        GET /{base}/patients?sort=-lastName
+        // 200 OK
+        Content-Type: application/json; charset=utf-8
+        "data": {
+            "patients": [
+            {
+                "NHSNumber": "9991234568",
+                "firstName": "Bernard",
+                "lastName": "Woolley",
+                // ... other patient details ...
+            },
+            {
+                "NHSNumber": "9991234567",
+                "firstName": "Jim",
+                "lastName": "Hacker",
+                // ... other patient details ...
+            },
+            {
+                "NHSNumber": "9991234566",
+                "firstName": "Humphrey",
+                "lastName": "Appleby",
+                // ... other patient details ...
+            }
+            // ... more patients ...
+            ]
+        }
+        }
+    ```

--- a/doc/restful-api-standards/testing.md
+++ b/doc/restful-api-standards/testing.md
@@ -1,0 +1,169 @@
+# Testing
+
+This section provides help for creating your API Test strategy and
+plans.
+
+## Shift left
+
+Test early in the API lifecycle and continue testing at every stage.
+This 'shift left' approach challenges you to develop T-shaped skills.
+For testers, this may involve writing code for automated tests. For
+developers, it means recognising that testing is a shared
+responsibility.
+
+!!! info "Further reading and information"
+    [What is Shifting Left Testing? \| Shift Left Meaning in Software Testing](https://smartbear.com/learn/automated-testing/shifting-left-in-testing/)
+
+## Automate as much as you can
+
+Test automation is crucial for shifting left and you **SHOULD** execute
+tests as part of your CI/CD pipelines. This practice helps identify and
+fix issues as they are introduced.
+
+!!! tip "Practical tips"
+    Consider automating tests for stories with frequent execution, critical functionality, stable requirements and variable data.
+
+## Validate the OpenAPI specification
+
+Check the [OpenAPI specification](open-api-specification.md) for structure
+and format to ensure the contract is correct. Use the *out-of-the-box*
+rules provided by linting tools like *Spectral* or *Postman Linter* to
+verify proper JSON and YAML formatting.
+
+It is **RECOMMENDED** you write a custom ruleset to enforce the rules
+described in this document.
+
+You **SHOULD** Inspect the API contract for the following, adding these
+checks to your CI/CD pipeline.
+
+- Endpoints are named correctly.
+
+- Resources and their types are accurate.
+
+- Relationships between resources are properly defined.
+
+- No functionality is missing or duplicated.
+
+!!! info "Further reading and information"
+    [API linting with Spectral \| What is it and how does it work?](https://blog.axway.com/learning-center/apis/api-design/api-linting-with-spectral#:~:text=Spectral%20allows%20automating%20some%20of,APIs%20follow%20the%20given%20rules.)
+
+## Unit tests
+
+Write unit tests as you build your API to catch issues early. Start with
+minimal tests and expand as necessary -- do not overcomplicate matters.
+
+You **SHOULD** add these tests to your CI/CD pipeline and publish code
+coverage metrics in a [Test Summary report](testing.md).
+
+## Functional tests
+
+Functional tests **SHOULD** verify that:
+
+- The correct HTTP headers and [HTTP status
+    codes](http-implementation.md) are returned.
+
+- The media type and its payload are correct, with appropriate field
+    names, types and values.
+
+- Endpoints behave according to the specified business logic and
+    requirements.
+
+### Test for failure
+
+Functional testing **SHOULD** include negative tests and check for valid
+error responses. These **SHOULD** cover scenarios for handling transient
+faults.
+
+### Behaviour driven development (bdd)
+
+Automate validation by incorporating BDD executable scenarios into your
+functional tests. For example:
+
+!!! example "Examples of good practice"
+    Scenario: Verify Successful Patient Retrieval
+
+    Given the API endpoint for retrieving patient data
+
+    When a GET request is made with a valid patient ID
+
+    Then the API should return a 200 OK status code
+
+    And the response should include correct patient information
+
+## Security tests
+
+Plan security testing with the API platform and cyber security teams.
+While many tests are executed against the proxy, you **SHOULD** also
+test the backend API for common vulnerabilities.
+
+Refer to the [Security](security-headers.md) section when planning your
+tests. Examples of common security tests include:
+
+- Input validation tests to prevent SQL injection attacks.
+
+- Verifying that only authorised users can access patient data.
+
+- Data encryption checks to confirm that data is transmitted over
+    HTTPS.
+
+- Rate limiting tests to detect and mitigate potential brute-force
+    attacks.
+
+## Performance tests
+
+You **MUST** check the [maximum response
+time](performance-and-response-times.md).
+
+You **SHOULD** consider whether to conduct, baseline, load, stress, soak
+and scalability tests.
+
+!!! tip "Practical tips"
+    Keep in mind that setting up the right environment can be challenging and that repeating tests consistently may be difficult due to network variations.
+
+## Usability tests
+
+You **SHOULD** test the entire API consumer journey including
+documentation, authentication and code examples, to ensure usability for
+users without prior knowledge of our systems.
+
+## Keep tests organised
+
+Tests **MUST** be organised and named according to our coding standards.
+
+!!! info "Further reading and information"
+    [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+
+    [General Coding Standards](../general-coding-standards/introduction.md)
+
+## Test summary report
+
+You **SHOULD** write a Test Summary report for every major, minor or
+patch version of your API. The content **MAY** vary depending on the
+version but you **SHOULD** consider including each of the following
+headings.
+
+!!! note
+    1. Static Analysis results (e.g. Spectral tests)
+
+    2. Code Metrics (e.g. code coverage based on results from automated tests)
+
+    3. Functional Tests
+
+    4. Security Tests (including references to any external pen test reports)
+
+    5. Performance Tests
+
+    6. Usability Tests
+
+!!! tip "Practical tips"
+    Some headings **MAY** be marked as "N/A" if not applicable for the version tested.
+
+!!! info "Further reading and information"
+    [How to write a Test Summary Report](../test-summary-report/introduction.md)
+
+    SDS-TEM-5 Test Summary Report Template
+
+## Test environment
+
+You **SHOULD** deploy APIs to a sandbox environment to allow client
+testing. Contact the platform team for further assistance.

--- a/doc/restful-api-standards/tooling.md
+++ b/doc/restful-api-standards/tooling.md
@@ -1,0 +1,18 @@
+# Tooling
+
+When choosing your API toolset, you **SHOULD** consider open-source
+options (e.g. Visual Studio Code). However, you **MAY** choose a
+subscription-based alternative (e.g. Visual Studio) if the cost is
+justified.
+
+## Recommended tools
+
+| **TOOL** | **CATEGORY** |
+| --- | --- |
+| Enterprise Architect with OpenAPI Plug-in SwaggerHub OpenAPI (Swagger) Editor Extension for VS Code | API Design and Documentation |
+| Visual Studio Code or Visual Studio | Code Editors and IDEs |
+| Firely.NET SDK xUnit SpecFlow RestSharp apickli (NPM Package) | SDKs |
+| Postman / Newman ReadyAPI (formerly SoapUI) REST Client (VS Code Extension) Thunder Client VS Code Extension) | API Testing and Automation |
+| Spectral Linter for VS Code Extension | API Specification and Linting |
+| OWASP ZAP Burp Suite Pro BrowserStack SonarQube (Cloud, Server IDE) GitHub Advanced Security for Azure DevOps Microsoft Security DevOps Azure DevOps extension | Security Testing and Quality Analysis |
+| Azure DevOps Docker Desktop Podman | DevOps and Containerisation |

--- a/doc/restful-api-standards/url-structure.md
+++ b/doc/restful-api-standards/url-structure.md
@@ -1,0 +1,28 @@
+# Url structure
+
+You **SHOULD** follow the structure below to ensure API endpoints are
+predictable & hierarchical.
+
+| **HEADER** | **DESCRIPTION** |
+| --- | --- |
+| Scheme / Protocol | **MUST** always be https://. |
+| Host / Domain | The platform team manages the domain structure, which **MAY** include a global API context in the fully qualified domain name (FQDN), followed by an environment and subdomain. |
+| Base path / Context | Represents a grouping of resource endpoints. Sometimes referred to as a Namespace. |
+| Version | Versioning requirements and URL rules are described in [Versioning](api-management.md). |
+| Resource / Resource collection | Represents the primary resource or resource collection exposed by the API. |
+| Resource identifier | A placeholder for the unique identifier of a resource within a collection. |
+| ?\[*Query parameters*\] | Used to filter and modify requests. Refer to the [Query Parameters](naming.md) section for reserved names. |
+
+!!! example "Examples of good practice"
+    `https://api.test.wales.nhs.uk/appointmentsService/patients?sort=firstName`
+
+    `https://api.test.wales.nhs.uk/appointmentsService/patients/{id}/conditions`
+
+    `https://api.test.wales.nhs.uk/appointmentsService/GPPractices/{id}/slots/{id}`
+
+    `https://api.test.wales.nhs.uk/referenceData/v2/GPPractices/{id}/Practitioners/{id}`
+
+    `https://api.test.wales.nhs.uk/appointmentsService/patients?sort=firstName`
+
+!!! tip "Practical tips"
+    Further examples in this document shorten the full URL structure for brevity.

--- a/doc/software-development-handbook/agile-delivery-using-scrum.md
+++ b/doc/software-development-handbook/agile-delivery-using-scrum.md
@@ -1,0 +1,112 @@
+# Agile delivery using Scrum
+
+We have adopted Scrum, having used a mix of project management
+approaches. Scrum replaces traditional staged development with Sprints
+and Scrum events.
+
+!!! note "**Sprint**"
+    A fixed-length period to **complete** small increments of working software.
+
+Manage each *Sprint* with these *Scrum* events:
+
+!!! note "**Planning**"
+    - Decide what work needs to be done.
+
+!!! note "**Daily Scrum**"
+    - Review progress and address impediments.
+
+!!! note "**Review**"
+    - Assess what has been achieved and gather feedback.
+
+!!! note "**Ret rospective**"
+    - Reflect on the *Sprint* discuss areas for improvement.
+
+!!! tip "Practical tips"
+    Continually refine requirements to make planning meetings easier!
+
+## Cross-functional Scrum Teams
+
+*Scrum* replaces technical silos with cross-functional teams. It
+identifies 3 roles --
+
+!!! note "**Product Owner**"
+    - Represents stakeholders and users.
+
+    - Defines, prioritises and refines backlog items.
+
+    - Works with the team to negotiate work during *Sprint* planning.
+
+    - Often a *Clinician* but can also be a *Product Specialist* or *Business Analyst.*
+
+!!! note "**Scrum Master**"
+    - Coaches and supports the *Scrum* team, helping them improve processes.
+
+    - Facilitates *Scrum* events and removes impediments.
+
+    - Often a *Software developer but can be anyone with strong facilitation and coaching skills.*
+
+!!! note "**Scrum Team**"
+    - Collaborates to negotiate work at *Sprint* planning.
+
+    - Delivers the work, ensuring it meets the acceptance criteria.
+
+    - Includes everyone needed to create the product
+
+!!! tip "Practical tips"
+    *Scrum* is reliant on having people committed to carrying out its 3 key roles!
+
+!!! info "Further reading and information"
+    [Home \| Scrum Guides](https://scrumguides.org/index.html)
+
+    [What is Scrum? - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/devops/plan/what-is-scrum)
+
+    [Sprint and scrum best practices - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/sprints/best-practices-scrum?view=azure-devops)
+
+## Agile practices for requirements gathering
+
+Scrum teams capture requirements in *User Stories*. But in some cases, a
+formal Software *Requirements Specification* may still be necessary.
+
+!!! note "**User Story**"
+    A brief description of a need, told from a user's perspective. With acceptance criteria written in Gherkin syntax to define 'done.'
+
+!!! tip "Practical tips"
+    - Ensure everyone understands the work involved.
+
+    - Consider hidden tasks to manage *technical debt*.
+
+    - Share common criteria in a *Definition of Done*, published to your Kanban board.
+
+!!! info "Further reading and information"
+    [Agile in Practice: Story Cards/User Stories - YouT ube](https://www.youtube.com/watch?v=LGeDZmrWwsw&app=desktop)
+
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [Good and Bad Technical Debt (and how TDD helps) - Crisp's Blog](https://blog.crisp.se/2013/10/11/henrikkniberg/good-and-bad-technical-debt)
+
+    [Testing for lost updates](../testing-lost-updates/introduction.md)
+
+## Agile planning with Azure DevOps
+
+Azure DevOps supports agile planning from backlog management to sprint
+execution:
+
+!!! note "**Agile process template**"
+    Provides essential work items like User Stories, Tasks, Bugs, and Test Scripts to support your agile workflow.
+
+!!! note "**Boards**"
+    **Kanban boards:** Visualise and manage requirements across all stages, independent of sprint cycles.
+
+    **Task Boards**: Track the status of tasks and their progress during sprints.
+
+!!! note "**Dashboard**"
+    Create customised dashboards to track key metrics such as test results, build quality, code coverage, and sprint burndown. This helps you monitor overall project health and progress.
+
+!!! info "Further reading and information"
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [Use agile process template artifacts - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/work-items/guidance/agile-process?view=azure-devops)
+
+    [Implement Scrum work practices in Azure Boards - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/sprints/scrum-overview?view=azure-devops)
+
+    [Best practices for Agile project management - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/best-practices-agile-project-management?view=tfs-2018&tabs=agile-process)

--- a/doc/software-development-handbook/development-principles.md
+++ b/doc/software-development-handbook/development-principles.md
@@ -1,0 +1,117 @@
+# Development principles
+
+## Ahdere to a solutions architecture
+
+Software **SHOULD** align with our API-first and Cloud-first strategies.
+Follow a Solutions Architecture Design, reviewed by the Technical Design
+Assurance Group, to meet these goals.
+
+!!! info "Further reading and information"
+    [RESTful API Design and Build Standards](../restful-api-standards/introduction.md)
+
+    [Architectural principles \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/architecture/modern-web-apps-azure/architectural-principles)
+
+## Write modular code
+
+Build modular code using APIs and NuGet packages.
+
+!!! info "Further reading and information"
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+!!! tip "Practical tips"
+    Sharing validated, trusted code is a principle of secure coding.
+
+## Use version control
+
+Effective source control is essential. Follow our [guide for help](../using-source-control/introduction.md).
+
+!!! note "Using source control"
+    - Structure repositories for clarity and scalability.
+
+    - Use consistent branching and merging strategies.
+
+    - Follow versioning conventions to track releases.
+
+    - Write clear, conventional commit messages.
+
+    - Conduct constructive code reviews.
+
+!!! info "Further reading and information"
+    [Using Source Control](../using-source-control/introduction.md)
+
+    [RESTful API Design and Build Standards](../restful-api-standards/introduction.md)
+
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [What is Git? - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/devops/develop/git/what-is-git)
+
+!!! tip "Practical tips"
+    Apply source control to databases and application code.
+
+## Follow coding standards
+
+Deliver reliable, maintainable software by adhering to these guides:
+
+!!! note
+    [T-SQL Coding Standard](../t-sql-coding-standard/introduction.md)
+
+    Rules for table design, maintainable queries, procedures, and transaction handling.
+
+!!! note
+    [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+
+    Guidance on project structure, folder conventions, documentation, and dependency layering.
+
+!!! note
+    [General Coding Standards](../general-coding-standards/introduction.md)
+
+    Clean code, defensive coding, implementing SOLID principles and Microsoft formatting and naming standards.
+
+!!! info "Further reading and information"
+    [T-SQL Coding Standard](../t-sql-coding-standard/introduction.md)
+
+    [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+
+    [General Coding Standards](../general-coding-standards/introduction.md)
+
+## Adopt Continuous Integration (CI) and Continuous Delivery (CD)
+
+All teams **MUST** use CI/CD to improve quality and accelerate the
+frequency of deployment.
+
+!!! info "Further reading and information"
+    [Use continuous integration - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/devops/develop/what-is-continuous-integration)
+
+    [What is continuous delivery? - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/devops/deliver/what-is-continuous-delivery)
+
+    [Continuous Delivery vs Continuous Deployment - Continuous Delivery](https://continuousdelivery.com/2010/08/continuous-delivery-vs-continuous-deployment/#:~:text=While%20continuous%20deployment%20implies%20continuous,in%20the%20hands%20of%20IT.&text=That%20means%20no%20more%20testing,you're%20using%20Scrum)
+
+    [What is DevOps? - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/devops/what-is-devops?view=azure-devops)
+
+For full guidance on how to implement CI/CD, refer to the references
+below:
+
+!!! info "Further reading and information"
+    [Using Source Control](../using-source-control/introduction.md)
+
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+## Publishing as open source
+
+The *Digital Service Standard for Wales* and the *Welsh Technical
+Standards Board* encourage making source code open. But this guide does
+not cover open-source publishing.
+
+If you plan to make your source code open, you **SHOULD** obtain the
+necessary approval and comply with any necessary organisational or legal
+requirements.
+
+!!! info "Further reading and information"
+    [Digital Service Standards - Digital Public Service Wales (gov.wales)](https://digitalpublicservices.gov.wales/toolbox/digital-service-standards/#work-open)
+
+    [Welsh Technical Standards Board \| A statement of principles](https://standards.cymru/posts/2018-12-01-wtsb/#4-open-by-default-open-technical-standards-and-open-source-code)
+
+    [Public Repos · GIGCymru/GitHub-GIG-Cymru Wiki](https://github.com/GIGCymru/GitHub-GIG-Cymru/wiki/Public-Repos)
+
+!!! tip "Practical tips"
+    Access to *github.com/GIGCymru/GitHub-GIG-Cymru/wiki/Public-Repos* requires a DHCW GitHub Enterprise account.

--- a/doc/software-development-handbook/development-tools.md
+++ b/doc/software-development-handbook/development-tools.md
@@ -1,0 +1,92 @@
+# Development tools
+
+## Technology stack
+
+In recent years we have expanded our tech stack, adopting tools like
+GitHub Enterprise, Google Cloud Platform (GCP) and PostgreSQL and
+programming languages like Python. However, teams in Operations and
+Primary Care and Mental Health primarily use the following:
+
+| **CATEGORY** | **TOOLS** |
+| --- | --- |
+| **DEVOPS** | - Azure DevOps |
+| **DEV ENVIRONMENT** | - Visual Studio or Visual Studio Code (preferred) - Git - SQL Toolbelt Essentials (mandatory when writing T-SQL) - HL7Edit |
+| **SERVER-SIDE DEVELOPMENT** | - .NET / ASP.NET with C# - Microsoft SQL Server with T-SQL - Azure |
+| **FRONT-END DEVELOPMENT** | - ASP.NET MVC with C# - .NET MAUI - Blazor - Client-side JavaScript |
+
+!!! tip "Practical tips"
+    A common toolset reduces complexity and avoids additional licencing costs.
+
+## Activate software subscriptions
+
+Development tools are not preinstalled on your laptop. Your line manager
+typically arranges a software subscription so you can install the tools.
+If not, follow our guide to request and manage subscriptions.
+
+!!! info "Further reading and information"
+    [How to request and manage software subscriptions](../software-subscriptions/introduction.md)
+
+    [Visual Studio Subscriptions \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/subscriptions/)
+
+## Setting up the development environment
+
+Our primary tools include Visual Studio, SQL Server Management Studio
+and Azure DevOps. Use the links below to set up your environment. Read
+our Azure DevOps Handbook to support its use.
+
+!!! info "Further reading and information"
+    [Select a development environment - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/devops/develop/selecting-development-environment)
+
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [Client version compatibility - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/server/compatibility?view=azure-devops)
+
+    [Sign in with work or school account - Visual Studio Subscription \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/subscriptions/sign-in-work)
+
+    [Download the Visual Studio IDE - Visual Studio Subscription \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/subscriptions/vs-ide-benefit#download-and-install-the-ide)
+
+    [Install Visual Studio and choose your preferred features \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/install/install-visual-studio?view=vs-2022)
+
+    [Connect to project from browser/supported client - Azure DevOps \| Microsoft L earn](https://learn.microsoft.com/en-gb/azure/devops/organizations/projects/connect-to-projects?bc=%2Fazure%2Fdevops%2Fget-started%2Fbreadcrumb%2Ftoc.json&toc=%2Fazure%2Fdevops%2Fget-started%2Ftoc.json&view=azure-devops&tabs=visual-studio-2019)
+
+    [Get started with Git and Visual Studio - Azure Repos \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/repos/git/gitquickstart?view=azure-devops&tabs=visual-studio-2022)
+
+    [What is SQL Server? - SQL Server \| Microsoft Learn](https://learn.microsoft.com/en-gb/sql/sql-server/what-is-sql-server?view=sql-server-ver16)
+
+!!! tip "Practical tips"
+    - Run Visual Studio as a standard user to follow the principle of least privilege.
+
+    - Use IIS Express instead of IIS.
+
+    - For new projects, consider SQL Server Developer Edition.
+
+## Keep frameworks up to date
+
+You **SHOULD** keep frameworks and dependencies current to minimise
+security risks.
+
+!!! tip "Practical tips"
+    **CANISC cyber security concerns**
+
+    In 2018, the National Assembly Public Accounts Committee flagged CANISC, the all-Wales Cancer system, as a cyber security risk due to discontinued Microsoft security updates.
+
+!!! info "Further reading and information"
+    [Microsoft .NET Framework - Microsoft Lifecycle \| Microsoft Learn](https://learn.microsoft.com/en-gb/lifecycle/products/microsoft-net-framework)
+
+    [.NET Framework official support policy (microsoft.com)](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework)
+
+    [.NET Official Support Policy (microsoft.com)](https://dotnet.microsoft.com/platform/support/policy)
+
+## Evaluating and adopting new tools
+
+If you need to use new or alternative tools you **SHOULD** follow these
+rules:
+
+- **Use widely adopted frameworks**: Choose those with dedicated
+    support, follow open standards and have good documentation.
+
+- **Check licencing**: Ensure Terms and Conditions are suitable for
+    use.
+
+- **Learn from others**: Base decisions on the experience gained by
+    other teams.

--- a/doc/software-development-handbook/documentation.md
+++ b/doc/software-development-handbook/documentation.md
@@ -1,0 +1,14 @@
+# Documentation
+
+Clear and comprehensive documentation is essential. All our guides and
+standards include sections on writing effective documentation. Key
+principles for good documentation include:
+
+- Follow company-wide writing guidelines and standards
+
+- Ensure docs reflects the current software version.
+
+- Automate documentation generation where possible (e.g., OpenAPI
+    specs).
+
+- Follow Conventional Commits for clear version control.

--- a/doc/software-development-handbook/essential-good-practice-checklists.md
+++ b/doc/software-development-handbook/essential-good-practice-checklists.md
@@ -1,0 +1,102 @@
+# Essential good practice checklists
+
+Use these checklists to help follow our Principles & Standards. We
+cross-reference each item to a relevant section in our standards or
+guides. Exceptions are noted where they may apply.
+
+## Requirements gathering, analysis and specifications
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 1 | You have a Product Owner. | ☐ | [Cross-functional Scrum Teams](agile-delivery-using-scrum.md) | *Only applies if you follow Scrum* |
+| 2 | You record user needs in *User Stories* or other Requirements Specifications. | ☐ | [Agile Practices for requirements gathering](agile-delivery-using-scrum.md) |  |
+| 3 | You record non-functional & other requirements in *User Stories* or Requirements Specifications. | ☐ | [Agile Practices for requirements gathering](agile-delivery-using-scrum.md) |  |
+| 4 | *User Stories* have clear acceptance criteria. | ☐ | [Agile Practices for requirements gathering](agile-delivery-using-scrum.md) |  |
+| 5 | You prefix a Service request Ids to the title of the *User Story* | ☐ | [Agile Practices for requirements gathering](agile-delivery-using-scrum.md) |  |
+| 6 | You link the service request in the User Story. | ☐ | [Agile Practices for requirements gathering](agile-delivery-using-scrum.md) |  |
+| 7 | You plan your approach to mitigating security risks at the start of the project. | ☐ | [Security](security.md) |  |
+
+### Planning, estimation and work tracking
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 8 | *Scrum* events are used to plan and track work. | ☐ | [Agile delivery using Scrum](agile-delivery-using-scrum.md) | *Only applies if you follow Scrum* |
+| 9 | You have a *Scrum* Master. | ☐ | [Cross-functional Scrum Teams](agile-delivery-using-scrum.md) | *Only applies if you follow Scrum* |
+| 10 | Your *Scrum* team is multi-disciplinary. | ☐ | [Cross-functional Scrum Teams](agile-delivery-using-scrum.md) | *Only applies if you follow Scrum* |
+| 11 | You record work items and defects using the Azure DevOps *Agile process template*. | ☐ | [Agile Planning with Azure DevOps](agile-delivery-using-scrum.md) |  |
+| 12 | You associate *Tasks* with *User Stories*. | ☐ | [Agile Planning with Azure DevOps](agile-delivery-using-scrum.md) |  |
+| 13 | You do **not** store Personal Identifiable Information (PII) in Azure DevOps. | ☐ | [Agile Planning with Azure DevOps](agile-delivery-using-scrum.md) |  |
+| 14 | You publish test, build quality, code coverage & burn down metrics in Azure DevOps dashboards. | ☐ | [Agile Planning with Azure DevOps](agile-delivery-using-scrum.md) |  |
+
+### Source control
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 15 | Everything needed to build your project, including databases, is under source control. | ☐ | [Use Version Control](development-principles.md) |  |
+| 16 | Sensitive data, such as API keys and passwords are stored in vaults & secrets and not in source control. | ☐ | [Use Version Control](development-principles.md) |  |
+| 17 | You follow the *Conventional Commits* specification. | ☐ | [Use Version Control](development-principles.md) |  |
+| 18 | Source code is peer reviewed. | ☐ | [Use Version Control](development-principles.md) | *May not be feasible for small teams. Nor always practical for bigger teams to peer review every code change.* |
+| 19 | You specify a minimum number of reviewers for code reviews. | ☐ | [Use Version Control](development-principles.md) |  |
+| 20 | You publish code review rules to a *README* or *CONTRIBUTING* markdown file. | ☐ | [Use Version Control](development-principles.md) |  |
+| 21 | You publish your approach to branching and merging in a *README* or *CONTRIBUTING* markdown file. | ☐ | [Use Version Control](development-principles.md) |  |
+| 22 | You store 3rd party dependencies in a common package feed. | ☐ | [Use Version Control](development-principles.md) |  |
+| 23 | You check open-source packages for licence compliance and known vulnerabilities. | ☐ | [Use Version Control](development-principles.md) |  |
+
+### Software design and maintainability
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 24 | You record your approach to maintainability and reusability in a Solutions Design. | ☐ | [Adhere to a Solutions Architecture Design](development-principles.md) |  |
+| 25 | You submit software designs for approval by the Technical Design Assurance Group. | ☐ | [Adhere to a Solutions Architecture Design](development-principles.md) |  |
+| 26 | You link to specifications and the Solutions Architecture Document in the User Story's 'All Links' tab. | ☐ | [Adhere to a Solutions Architecture Design](development-principles.md) |  |
+| 27 | You use design patterns to solve common problems. | ☐ | [Adhere to a Solutions Architecture Design](development-principles.md) |  |
+| 28 | You deploy APIs via an API Management solution. | ☐ | [Adhere to a Solutions Architecture Design](development-principles.md) |  |
+| 29 | You keep Software frameworks are kept up to date with long-term support. | ☐ | [Keep frameworks up-to-date](development-tools.md) |  |
+
+### Coding standards
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 30 | Your software solution is organised according to our conventions. | ☐ | [Follow our coding standards](development-principles.md#follow-coding-standards) | This may not be feasible for some legacy codebases. |
+| 31 | You provide a *README.md* file in the root folder. | ☐ | [Follow our coding standards](development-principles.md#follow-coding-standards) |  |
+| 32 | You use *SOLID* principles to make your code more testable. | ☐ | [Follow our coding standards](development-principles.md#follow-coding-standards) |  |
+| 33 | You follow our conventions for naming unit tests. | ☐ | [Follow our coding standards](development-principles.md#follow-coding-standards) |  |
+| 34 | You employ a common approach to logging exceptions. | ☐ | [Follow our coding standards](development-principles.md#follow-coding-standards) |  |
+| 35 | You use our common SQL Prompt settings files to format T-SQL. | ☐ | [Follow our coding standards](development-principles.md#follow-coding-standards) |  |
+| 36 | Your software meets all relevant accessibility standards. | ☐ | [User interface and accessibility standards](user-interface-and-accessibility-standards.md) |  |
+| 37 | You mitigate application vulnerabilities. | ☐ | [Security](security.md) |  |
+| 38 | You perform code analysis checks | ☐ | [Security](security.md) |  |
+
+### Observing a definition of done
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 39 | You publish common acceptance criteria in a *Definition of Done*. | ☐ | [Agile Practices for requirements gathering](agile-delivery-using-scrum.md) |  |
+| 40 | You automate regression testing. | ☐ | [Adopt Continuous Integration (CI) and Continuous Delivery (CD)](development-principles.md) | *Some frameworks and legacy code may make impractical to write automated unit tests.* |
+| 41 | Test Analysts peer review unit tests. | ☐ | [Testing](../restful-api-standards/testing.md) |  |
+| 42 | You add a commit message prior to checking code into source control. | ☐ | [Use Version Control](development-principles.md) |  |
+| 43 | You test during each *Sprint*. | ☐ | [Testing](../restful-api-standards/testing.md) | *Only applies if you follow Scrum* |
+| 44 | You issue a *Test Summary Report* prior to each deployment. | ☐ | [Testing](../restful-api-standards/testing.md) |  |
+| 45 | You agree opportunities for improvement at *Sprint* retrospectives. | ☐ | [Agile delivery using Scrum](agile-delivery-using-scrum.md) | *Only applies if you follow Scrum* |
+| 46 | You account for security threats and vulnerabilities. For example, by adding security risk mitigations and a corresponding testing strategy to your definition of done. | ☐ | [Security](security.md) |  |
+
+### Deployment
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 47 | You can identify the work items associated with each release. | ☐ | [Use Version Control](development-principles.md) |  |
+| 48 | Your branching and merging strategy identifies a release branch. | ☐ | [Use Version Control](development-principles.md) |  |
+| 49 | You apply rules or policies to your release branch to prevent improper use. | ☐ | [Use Version Control](development-principles.md) |  |
+| 50 | You maintain permissions on your project to prevent improper access. | ☐ | [Use Version Control](development-principles.md) |  |
+| 51 | Your deployments are triggered by commits to source control. | ☐ | [Adopt Continuous Integration (CI) and Continuous Delivery (CD)](development-principles.md) | *Only applies if you practice trunk-based development.* |
+| 52 | You maintain a deployment checklist or automated build & deployment script. | ☐ | [Adopt Continuous Integration (CI) and Continuous Delivery (CD)](development-principles.md) |  |
+| 53 | You publish instructions on how to build and deploy your software in a *README* or *CONTRIBUTING* markdown file. | ☐ | [Follow our coding standards](development-principles.md#follow-coding-standards) |  |
+| 54 | You can easily rollback to a previous release when required. | ☐ | [Use Version Control](development-principles.md) |  |
+
+### Governance of technologies
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 55 | You have the appropriate licences or subscriptions for the tools you use. | ☐ | [Activate software subscriptions](development-tools.md) |  |
+| 56 | You comply with licencing terms and conditions for any 3rd party software you use, including open-source software. | ☐ | [Activate software subscriptions](development-tools.md) |  |
+| 57 | You seek agreement from the Software Development Manager, Lead Developers group or Application & Architecture Assurance group before choosing a new technology. | ☐ | [Evaluating and adopting new tools](development-tools.md) |  |

--- a/doc/software-development-handbook/exceptions.md
+++ b/doc/software-development-handbook/exceptions.md
@@ -1,0 +1,10 @@
+# Exceptions
+
+While there may be reasons to deviate from this guide, exceptions should
+be rare and carefully considered. As adhering to standards is crucial in
+meeting Welsh Government's design standards,
+
+!!! info "Further reading and information"
+    [Digital Service Standard for Wales \| Centre for Digital Public Services](https://digitalpublicservices.gov.wales/guidance-and-standards/digital-service-standard-wales)
+
+    [Welsh Technical Standards Board \| A statement of principles](https://standards.cymru/posts/2018-12-01-wtsb/)

--- a/doc/software-development-handbook/introduction.md
+++ b/doc/software-development-handbook/introduction.md
@@ -1,0 +1,71 @@
+# Introduction
+
+## Purpose
+
+A guide to managing software development projects for Digital Health and
+Care Wales.
+
+## Scope
+
+### In-scope
+
+- Good practice for requirements gathering, building, testing, and
+    deploying software.
+
+- [Practical checklists for good
+    practice](essential-good-practice-checklists.md).
+
+### Out-of-scope
+
+- Broader lifecycle topics, including project inception, software
+    architecture, user acceptance testing and operations.
+
+- Guidance on publishing software as open source.
+
+- In-depth instructions; this guide links to other standards instead.
+
+## Roles and responsibilities
+
+Application and Product teams in the Operations and Primary Care and
+Mental Health directorates have a responsibility to follow this guide.
+
+## References
+
+1. Digital Service Standard for Wales
+2. Welsh Technical Standards Board Statement of Principles
+3. [How to request and manage software subscriptions](../software-subscriptions/introduction.md)
+4. [Using Source Control](../using-source-control/introduction.md)
+5. [T-SQL Coding Standard](../t-sql-coding-standard/introduction.md)
+6. [RESTful API Design and Build Standards](../restful-api-standards/introduction.md)
+7. [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+8. [General Coding Standards](../general-coding-standards/introduction.md)
+9. [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+10. Informatics Systems in Wales, National Assembly for Wales, Public Accounts Committee
+11. SOP-OSD-004 - Web Applications
+12. SOP-OSD-005 - Encryption in Transit
+13. SOP-OSD-006 - Application Programming Interfaces
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions. If a link is missing, search for the document in the Document Management System.
+
+## The need for guidance
+
+Developing software for healthcare needs consistent, robust practices.
+Following clear processes and good practice helps you deliver robust and
+secure solutions.

--- a/doc/software-development-handbook/security.md
+++ b/doc/software-development-handbook/security.md
@@ -1,0 +1,30 @@
+# Security
+
+DHCW adheres to the ISO 27001 standard for Information security
+management. To comply with certification requirements, you **MUST**
+follow secure development practices, including:
+
+- Analysing code for quality and vulnerabilities.
+
+- Applying branch policies and security controls to restrict access to
+    code repos.
+
+- Implementing vulnerability scanning within CI and CD pipelines.
+
+- Keeping systems updated with the latest security patches.
+
+- Ensuring encryption of data in transit and at rest.
+
+More detailed guidance, refer to the relevant documents below.
+
+!!! info "Further reading and information"
+    [General Coding Standards](../general-coding-standards/introduction.md)
+
+    SOP-OSD-004 Web Applications
+
+    SOP-OSD-005 Encryption in Transit
+
+    SOP-OSD-006 Application Programming Interfaces
+
+!!! tip "Practical tips"
+    Security standards are not published to our document management system, iPassport. Contact the Cyber Security team to obtain the latest versions.

--- a/doc/software-development-handbook/testing.md
+++ b/doc/software-development-handbook/testing.md
@@ -1,0 +1,27 @@
+# Testing
+
+Testing **MUST** align with our Test Framework. Following it and
+producing Test Summary Reports is key to meeting our Informatics
+Assurance Process.
+
+!!! tip "Practical tips"
+    Log defects in Azure DevOps using work items like Bugs, Test Plans, and Test Cases.
+
+!!! info "Further reading and information"
+    Test Framework
+
+    [Testing for lost updates](../testing-lost-updates/introduction.md)
+
+    [How to write a Test Summary Report](../test-summary-report/introduction.md)
+
+    Test Strategy Template
+
+    Test Plan Template
+
+    SDS-TEM-5 Test Summary Report Template
+
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [Shift testing left with unit tests - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/devops/develop/shift-left-make-testing-fast-reliable)
+
+    [Introducing the Software Testing Cupcake (Anti-Pattern) \| Thoughtworks](https://www.thoughtworks.com/en-gb/insights/blog/introducing-software-testing-cupcake-anti-pattern)

--- a/doc/software-development-handbook/user-interface-and-accessibility-standards.md
+++ b/doc/software-development-handbook/user-interface-and-accessibility-standards.md
@@ -1,0 +1,23 @@
+# User interface and accessibility standards
+
+Software **SHOULD** be intuitive and accessible. Design decisions must
+prioritise safety and accessibility. Keep in mind the following
+principles:
+
+!!! note "**User-Centred Design**"
+    Engage end-users early and often to understand their needs. Design interfaces that align with their tasks.
+
+!!! note "**Accessibility**"
+    Adhere to WCAG 2. Level AA standards at a minimum. Ensure all features are accessible to users with disabilities, including compatibility with assistive technologies.
+
+!!! note "**Consistency**"
+    Provide a consistent user experience across DHCW applications. Follow the Single Record Product's UI Standard for internal clinical applications and the NHS Design System for public-facing services.
+
+!!! info "Further reading and information"
+    Single Record Products UI Standard
+
+    [Design system - NHS digital service manual](https://service-manual.nhs.uk/design-system)
+
+    [Digital Health and Care Wales Brand](https://nhswales365.sharepoint.com/sites/DHCW_CORP_Graphics/SitePages/Home.aspx)
+
+    [WCAG 2 Overview \| Web Accessibility Initiative (WAI) \| W3C](https://www.w3.org/WAI/standards-guidelines/wcag/)

--- a/doc/software-subscriptions/cancelling-a-subscription.md
+++ b/doc/software-subscriptions/cancelling-a-subscription.md
@@ -1,0 +1,7 @@
+# Cancelling a subscription
+
+YOU **MUST** request the cancellation of a subscription when it is no
+longer needed. For example when a team member leaves their role.
+
+!!! tip "Practical tips"
+    **Note:** Azure DevOps Basic and Basic + Test Plans subscriptions may be downgraded to Stakeholder status if there has been no access for over 8 weeks.

--- a/doc/software-subscriptions/identify-the-subscription-you-need.md
+++ b/doc/software-subscriptions/identify-the-subscription-you-need.md
@@ -1,0 +1,41 @@
+# Identify the subscription you need
+
+Use this section to determine the common subscriptions you need.
+
+## Subscription benefits
+
+| **SUBSCRIPTION** | **KEY BENEFITS** |
+| --- | --- |
+| **Visual Studio Enterprise with GitHub Enterprise** | Visual Studio Enterprise IDE Basic access to Azure DevOps GitHub Enterprise subscription Azure personal credits \$150 per month |
+| **Visual Studio Professional with GitHub Enterprise** | Visual Studio Professional IDE Basic access to Azure DevOps GitHub Enterprise subscription Azure personal credits \$50 per month |
+| **Visual Studio Test Professional** | Access to Azure DevOps + Azure Test Plans Azure personal credits \$50 per month |
+| **MSDN Platforms** | Access to Azure DevOps + Azure Test Plans Azure personal credits \$100 per month |
+| **Azure DevOps Stakeholder** | Limited access to Azure DevOps |
+| **Azure DevOps Basic** | Basic access to Azure DevOps |
+| **Azure DevOps Basic + Test Plans** | Access to Azure DevOps + Azure Test Plans |
+| **SQL Toolbelt** | Comprehensive SQL Server tools (development & administration) |
+| **SQL Toolbelt Essentials** | Essential SQL Server tools |
+| **SQL Monitor** | SQL Server performance monitoring (alerting and reporting) |
+| **dotUltimate** | .NET tools ReSharper Rider IDE |
+| **IntelliJ IDEA Ultimate** | Java and Kotlin IDE |
+| **Rider** | Rider IDE |
+| **HL7 Edit Professional** | HL7 Edit Licence |
+
+## Role requirements
+
+The table below acts as a quick rule of thumb to match your job role
+with suitable subscriptions.
+
+| **ROLE** | **SUBSCRIPTION(S)** |
+| --- | --- |
+| PRODUCT OWNER | Azure DevOps Basic |
+| SCRUM TEAM MEMBER | Azure DevOps Basic |
+| MANUAL TESTING | Visual Studio Test Professional or Azure DevOps Basic + Test Plans, HL7 Edit Licence |
+| TEST AUTOMATION| Visual Studio Professional with GitHub Enterprise, Visual Studio Test Professional or Azure DevOps Basic + Test Plans, GitHub CoPilot Business |
+| WEB DEVELOPER | Visual Studio Professional with GitHub Enterprise |
+| MOBILE DEVELOPER| Visual Studio Professional with GitHub Enterprise, dotUltimate or Rid |
+| INTEGRATION DEVELOPER |Visual Studio Professional with GitHub Enterprise, Visual Studio Test Professional or Azure DevOps Basic + Test Plans, HL7 Edit Licence |
+| SQL DATABASE DEVELOPER |Azure DevOps BasicSQL Toolbelt Essentials |
+
+!!! tip "Practical tips"
+    While *Visual Studio Professional* and *Enterprise* subscriptions licence the use of ***GitHub*** and allow you to buy extras like [*GitHub Copilot Business*](requesting-a-subscription.md), further steps are needed on receipt of the subscription to do so. Contact the Software Development Manager for details.

--- a/doc/software-subscriptions/introduction.md
+++ b/doc/software-subscriptions/introduction.md
@@ -1,0 +1,89 @@
+# Introduction
+
+## Purpose
+
+- Lists the common software subscriptions used for software
+    development.
+
+- Helps you identify the subscriptions needed.
+
+- Explains how to request or cancel a subscription.
+
+- Describes how to manage common subscriptions, including assignment
+    and removal.
+
+- Describes other known subscriptions in use.
+
+- Aligns with the IT Asset Management Policy.
+
+## Scope
+
+### In-scope
+
+- Common software subscriptions used by teams writing DHCW software.
+
+### Out-of-scope
+
+- Steps to add a new software subscription to the common portfolio.
+
+- Managing subscription agreements, Contact Commercial Services for
+    help.
+
+- Asset management. But it may support aspects of the Asset Management
+    Policy.
+
+## Roles & responsibilities
+
+### Dhcw staff
+
+Staff have a responsibility to :-
+
+- Request subscriptions needed to ensure software is licenced.
+
+- Keep software up-to-date by applying updates and security patches
+    promptly.
+
+- Request removal of subscriptions when they are no longer needed,
+
+### Software development manager
+
+The Software Development Manager has a responsibility to :-
+
+- Process requests for common subscriptions.
+
+- Balance adequate inventory with minimising excess costs.
+
+- Manage underpinning contract agreements.
+
+- Provide advice and guidance on software subscriptions and related
+    topics.
+
+## References
+
+| INDEX NUMBER | DOCUMENT NAME |
+| --- | --- |
+| N/A | [RFC 2119: RFC Keywords (ietf.org)](https://www.ietf.org/rfc/rfc2119.txt) |
+| DHCW-POL-2 | IT Asset Management Policy |
+
+## How this guide is organised
+
+### Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions.
+
+    If a hyperlink is missing, search for the document in the Document Management System.

--- a/doc/software-subscriptions/managing-subscriptions.md
+++ b/doc/software-subscriptions/managing-subscriptions.md
@@ -1,0 +1,24 @@
+# Managing subscriptions
+
+Subscriptions are typically managed using the vendor's management
+portal or, in the case of Azure DevOps, via the Azure DevOps software
+itself. One exception is *HL7 Edit* licenses, which are tracked using a
+spreadsheet.
+
+The following links are used to assign subscriptions by the Software
+Development Manager.
+
+| **SUBSCRIPTION** | **LINK** |
+| --- | --- |
+| Visual Studio Enterprise with GitHub Enterprise | <https://manage.visualstudio.com/Subscribers> |
+| Visual Studio Professional with GitHub Enterprise |  |
+| Visual Studio Test Professional |  |
+| MSDN Platforms |  |
+| Azure DevOps | <https://dev.azure.com/NHS-Wales-Digital/_settings/users> |
+| SQL Toolbelt | [http://www.red-gate.com/](http://www.red-gate.com/Dynamic/Auth/Login?ref=account-nav) |
+| SQL Toolbelt Essentials |  |
+| SQL Monitor |  |
+| dotUltimate | <https://account.jetbrains.com/licenses> |
+| IntelliJ IDEA Ultimate |  |
+| Rider |  |
+| HL7 Edit Professional | [HL7Edit Licences.xlsx](https://nhswales365.sharepoint.com/:x:/r/sites/DHC_SD/_layouts/15/Doc.aspx?sourcedoc=%7BE3CD676E-7AB5-4A5C-8C1F-A7399AA4D88C%7D&file=HL7Edit%20Licences.xlsx&action=default&mobileredirect=true) |

--- a/doc/software-subscriptions/requesting-a-subscription.md
+++ b/doc/software-subscriptions/requesting-a-subscription.md
@@ -1,0 +1,40 @@
+# Requesting a subscription
+
+You can request a common subscription from the Software Development
+Manager by logging a call to the **Corporate Applications** team, for
+the attention of the Software Development Manager.
+
+If you need an Azure DevOps subscription, check with the Azure DevOps
+Organisation owner first. As only subscriptions for the
+*NHS-Wales-Digital* Azure DevOps instance can be allocated by the
+Software Development Manager.
+
+When requesting a subscription for a new member of staff, you **SHOULD**
+do so before their start date. While we aim to process requests on the
+same day this isn't always possible.
+
+For agency staff you **MUST** provide a cost code along with their
+contract start and end dates. Ask the contract manager to supply these.
+
+!!! tip "Practical tips"
+    If the Software Development Manager is unavailable or the request cannot be processed, download a trial version until your request is handled.
+
+## Requesting GitHub copilot business
+
+Follow these steps to request *GitHub Copilot Business*, an AI-powered
+coding assistant for your development environment. *Note*: You'll
+also need a *GitHub Enterprise* subscription.
+
+1. First, check if you already have GitHub Enterprise. *VS Enterprise* and
+    *VS Professional* include it by default, but *VS Test Professional* does not.
+
+2. It's often worth having a *VS Professional* subscription anyway.
+    Raise a service request to the **Corporate Applications team**,
+    addressed to the Software Development Manager. They will allocate
+    the subscription and forward your request for *GitHub CoPilot Business*.
+
+3. If you don't need a *VS Professional* subscription, raise a service
+    request to the **GitHub GIG CYMRU** **team**. They'll allocate
+    *GitHub Copilot Business (*and *GitHub Enterprise* if needed).
+    *Note*: You may need to provide extra information, such as a
+    cost code.

--- a/doc/software-subscriptions/what-subscriptions-are-available.md
+++ b/doc/software-subscriptions/what-subscriptions-are-available.md
@@ -1,0 +1,60 @@
+# What subscriptions are available?
+
+This section lists the common subscriptions available across DHCW and
+managed by the Software Development Manager.
+
+It also sets out a list of tools used by individual teams for activities
+like design, prototyping and planning. But details about how they are
+managed vary. Speak to the Software Development Manager for help.
+**Note**: This list is not intended to be exhaustive.
+
+## Common subscriptions
+
+| **VENDOR** | **SUBSCRIPTION** | **CONTACT** |
+| --- | --- | --- |
+| **Microsoft** | Visual Studio Enterprise with GitHub Enterprise | Software Development Manager |
+|  | Visual Studio Professional with GitHub Enterprise |  |
+|  | Visual Studio Test Professional |  |
+|  | MSDN Platforms |  |
+|  | Azure DevOps Stakeholder |  |
+|  | Azure DevOps Basic |  |
+|  | Azure DevOps Basic + Test Plans |  |
+| **Redgate** | SQL Toolbelt |  |
+|  | SQL Toolbelt Essentials |  |
+|  | SQL Monitor |  |
+| **JetBrains** | dotUltimate |  |
+|  | IntelliJ IDEA Ultimate |  |
+|  | Rider |  |
+| **Real Seven** | HL7 Edit Professional |  |
+
+!!! info "Further reading and information"
+    [Visual Studio Subscriptions - Visual Studio](https://visualstudio.microsoft.com/subscriptions/)
+
+    [About access levels - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/security/access-levels?view=azure-devops)
+
+## Tools for targeted needs
+
+| **TOOL or PRODUCT SUITE** |
+| --- |
+| **ALTOVA XML SPY** |
+| **Balsamiq** |
+| **DEVEXPRESS VCL COMPONENTS** |
+| **DIGITAL METAPHORS REPORT BUILDER** |
+| **Docker BUSINESS** |
+| **EMBARCADERO DELPHI** |
+| **FIGMA** |
+| **FLOAT** |
+| **github enterprise subscription** |
+| **github copilot business** |
+| **MIRO** |
+| **ORACLE DATABASE ENTERPRISE EDITION** |
+| **PRODUCTBOARD** |
+| **SKILLSOFT PERCIPIO** |
+| **SPARX SYSTEMS ENTERPRISE ARCHITECT** |
+| **SPARX SYSTEMS PROLABORATE** |
+| **Atlassian TRELLO** |
+| **UPSCENE DATABASE WORKBENCH** |
+| **Microsft VISIO** |
+
+!!! tip "Practical tips"
+    It is **RECOMMENDED** you check plans for ongoing software assurance when requesting a subscription.

--- a/doc/t-sql-coding-standard/aliases.md
+++ b/doc/t-sql-coding-standard/aliases.md
@@ -1,0 +1,11 @@
+# Aliases
+
+You **SHOULD**:-
+
+- Alias *ALL* table names using the convention AS *<alias\>*.
+
+- Use meaningful alias names, following our naming conventions
+    (see later in this document.)
+
+- Qualify each column with the parent table or alias, especially
+    where the parent table is part of a join or subquery.

--- a/doc/t-sql-coding-standard/apply-code-analysis-rules.md
+++ b/doc/t-sql-coding-standard/apply-code-analysis-rules.md
@@ -1,0 +1,86 @@
+# Apply code analysis rules
+
+You **SHOULD**: -
+
+- Specify column names when using `INSERT`, even when inserting data
+    into all columns.
+
+- Expand the asterisk wildcard to explicitly define all columns.
+
+- Qualify object names. Prefix each reference to a table with its
+    schema (but not the database name) and each column to its parent
+    table (or alias) in `SELECT` statements.
+
+- Terminate all statements with a semi-colon and with no leading
+    whitespace.
+
+- Favour `EXISTS` or table joins over `IN` or `COUNT` where it's sensible to
+    do so.
+
+- Include an `ELSE` block with each `CASE` expression.
+
+- Prefer the use of `SCOPE_IDENTITY()` to `@@IDENTITY`.
+
+- Use Common Table Expressions (CTEs) instead of non-correlated
+    subqueries. A `CTE` is easier to read than a subquery and offers the
+    same performance.
+
+- Use functions like `ISNULL`, `IS NULL`, `ISNUMERIC`, `TRY_CONVERT`, `COALESCE` and** `CAST` correctly.
+
+You **SHOULD NOT**:-
+
+- Use `INSERT INTO` *<table\>* with an `ORDER BY` clause. The order
+    depends on the clustered index if one is defined.
+
+- Use `DELETE` without a `WHERE` or `INNER JOIN` clause
+
+- Use `UPDATE` without a `WHERE` or `INNER JOIN` clause
+
+- Use correlated sub-queries. (The exception to this is the use of
+    `EXISTS`.)
+
+- Define `JOIN` conditions in the `WHERE` clause. Include the
+    `JOIN` condition in the `ON` clause.
+
+- Include `WHERE` clauses in `SELECT` statements[^1] to
+    prevent defining Cartesian joins.
+
+- Use `ISNULL` in a `WHERE` or `JOIN` clause. Expressions need
+    to use `IS NOT NULL` and the `COALESCE` function to handle
+    `NULL` values appropriately.
+
+- Use comparison operators against a `NULL` value.
+
+- Use `DISTINCT` where it is not required. Use a `GROUP BY` clause
+    where possible and check `JOIN` conditions to eliminate duplicate
+    rows.
+
+- Use wildcards (such as %) at the start of `LIKE` in `WHERE` clauses.
+    Indexes *cannot* support wildcard queries at the start of a `LIKE`
+    expression.
+
+- Reference columns that do not have indexes in a `WHERE`, `JOIN`
+    or `ORDER BY` clause.
+
+- Use system or user-defined scalar functions in a `WHERE` or
+    `JOIN` clause. Functions are evaluated for each row in the result
+    set. Any indexes cannot be used on the column the function is being
+    performed on.
+
+- Use the `NOLOCK` hint. It's safer to specify the correct isolation
+    level instead.
+
+!!! tip "Practical tips"
+    Use Redgate SQL Prompt to help you implement code analysis rules. See [Follow our code layout rules](follow-our-code-layout-rules.md)
+
+!!! info "Further reading and information"
+    [Code Analysis - Product Documentation (re d-gate.com)](https://documentation.red-gate.com/codeanalysis)
+
+    [How to Get NULLs Horribly Wrong in SQL Server - Simple Talk (red-gate.com)](https://www.red-gate.com/simple-talk/databases/sql-server/t-sql-programming-sql-server/how-to-get-nulls-horribly-wrong-in-sql-server/)
+
+    [SQL Server Common Table Expression (CTE) Basics - Simple Talk (red -gate.com)](https://www.red-gate.com/simple-talk/databases/sql-server/t-sql-programming-sql-server/sql-server-cte-basics/)
+
+    [Lookup Table Madness -- SQLServerCentral](https://www.sqlservercentral.com/articles/lookup-table-madness)
+
+[^1]: If you need to perform a Cartesian join, use the newer syntax
+    `CROSS APPLY` -- most likely when shredding XML/JSON data.

--- a/doc/t-sql-coding-standard/avoid-using-t-sql-to-execute-business-logic.md
+++ b/doc/t-sql-coding-standard/avoid-using-t-sql-to-execute-business-logic.md
@@ -1,0 +1,6 @@
+# Avoid using T-SQL to execute business logic
+
+As a rule, you **SHOULD NOT** place business logic in the database.
+
+!!! info "Further reading and information"
+    [Should we use stored procedures or queries built in the app? - Brent Ozar Unlimited®](https://www.brentozar.com/archive/2019/03/should-we-use-stored-procedures-or-queries-built-in-the-app/)

--- a/doc/t-sql-coding-standard/code-comments.md
+++ b/doc/t-sql-coding-standard/code-comments.md
@@ -1,0 +1,5 @@
+# Code comments
+
+You **SHOULD** use the code headers provided in SQL Server Management
+Studio's (SSMS) default templates to comment scripts, stored procedures,
+functions and the like.

--- a/doc/t-sql-coding-standard/date-and-time.md
+++ b/doc/t-sql-coding-standard/date-and-time.md
@@ -1,0 +1,36 @@
+# Date and time
+
+You **SHOULD**: -
+
+- Use a suitable date / time datatype. Their precision differs and
+    affects the performance of your queries accordingly.
+
+- Express dates in ISO format to remove ambiguity. For example,
+    12/04/2017 may be interpreted as 12th April or 4th December
+    depending on your configuration.
+
+!!! example "Examples of good practice"
+    Use year, month day yyyymmdd format for a date alone (e.g., 20171204)
+
+    Use year, month, day and time format yyyy-MM-ddThh:mm:ss.xxx for a date & time (e.g. 2017-12-04T14:24:30.123)
+
+- Cast `DATETIME` or `SMALLDATETIME` fields to `DATE` if
+    you're interested only in the date part. SQL Server supports this.
+
+You **SHOULD NOT**:-
+
+- Use `DATEDIFF` when searching date ranges. As with other functions,
+    this prevents the database engine making use of any indexes.
+
+- Use `BETWEEN` for searching datetime ranges. The start and end of the
+    range can appear ambiguous. Use the operators \>*,* <*,* \>=*,*
+    <=*,* = instead.
+
+- Use the *+* or *--* operators on date/time fields; It is unclear
+    what unit is being applied. For example, it's not clear that
+    `GETDATE()+1` will return this time tomorrow. Newer datatypes such as
+    `DATE`, `DATETIME2` and `DATETIMEOFFSET` throw errors when used in this
+    way.
+
+!!! info "Further reading and information"
+    [How to Get SQL Server Dates and Times Horribly Wrong - Simple Talk (red-gate.com)](https://www.red-gate.com/simple-talk/databases/sql-server/t-sql-programming-sql-server/how-to-get-sql-server-dates-and-times-horribly-wrong/)

--- a/doc/t-sql-coding-standard/examples.md
+++ b/doc/t-sql-coding-standard/examples.md
@@ -1,0 +1,461 @@
+# Examples
+
+## Insert statement
+
+In this example we make sure to
+
+- Qualify table names with the schema name.
+
+- Specify `INSERT` columns.
+
+!!! warning "Practices to avoid"
+    ```sql
+        INSERT INTO SubscribingConsultant
+        VALUES ('7A5', 'C1234567');
+    ```
+
+!!! example "Examples of good practice"
+    ```sql
+        [INSERT INTO dbo.SubscribingConsultant(Organisation, ConsultantId)]
+        [VALUES('7A5', 'C1234567\');]
+    ```
+
+## Select statement
+
+In this example we make sure to
+
+- Qualify table names with the schema name.
+
+- Add a meaningful table alias name.
+
+- Use the field name in the `ORDER BY` clause rather than a constant.
+
+!!! warning "Practices to avoid"
+    ```sql
+        SELECT Report.Id, Report.SubjectGivenName AS FirstName, Report.SubjectFamilyName AS LastName
+        FROM Report
+        ORDER BY 1 ASC;
+    ```
+
+!!! example "Examples of good practice"
+    ```sql
+        SELECT Report.Id, Report.SubjectGivenName AS FirstName, Report.SubjectFamilyName AS LastName
+        FROM dbo.Report AS Report
+        ORDER BY Report.Id ASC;
+    ```
+
+## Queries
+
+In this next example, we will step through a query making sure to: -
+
+1. Expand wildcards searches.
+
+2. Qualify table names with the schema name.
+
+3. Add a meaningful table alias name.
+
+4. Qualify column names with table alias.
+
+5. Add a meaningful column alias name[^1].
+
+6. Alias the column name using the AS convention.
+
+7. Add the semi colon terminator.
+
+!!! warning "Practices to avoid"
+    ```sql
+        SELECT * FROM Report
+
+        SELECT Report.Id, SubjectGivenName f, Report.SubjectFamilyName
+        FROM Report
+
+        SELECT Report.Id, SubjectGivenName f, Report.SubjectFamilyName
+        FROM dbo.Report
+
+        SELECT Report.Id, SubjectGivenName f, Report.SubjectFamilyName
+        FROM dbo.Report AS Report
+
+        SELECT Report.Id, Report.SubjectGivenName f, Report.SubjectFamilyName
+        FROM dbo.Report AS Report
+        
+        SELECT Report.Id, Report.SubjectGivenName FirstName, Report.SubjectFamilyName
+        FROM dbo.Report AS Report
+
+        SELECT Report.Id, Report.SubjectGivenName AS FirstName, Report.SubjectFamilyName
+        FROM dbo.Report AS Report
+    ```
+
+!!! example "Examples of good practice"
+    ```sql
+        SELECT Report.Id, Report.SubjectGivenName AS FirstName, Report.SubjectFamilyName
+        FROM dbo.Report AS Report;
+    ```
+
+## Dates #1
+
+In this example, we ensure that a query against a date field can use the
+index.
+
+!!! warning "Practices to avoid"
+    ```sql
+        SELECT ObservationRequest.ReportId FROM dbo.ObservationRequest ObservationRequest
+        WHERE CONVERT(VARCHAR(10), ObservationRequest.AuthorisedDateTime, 112) = '2018-12-12';
+    ```
+
+!!! example "Examples of good practice"
+    ```sql
+        SELECT ObservationRequest.ReportId
+        FROM dbo.ObservationRequest ObservationRequest
+        WHERE CAST(ObservationRequest.AuthorisedDateTime AS DATE) = '2018-12-12';
+    ```
+
+## Dates #2
+
+We step through the next example ensuring to
+
+1. Eliminate the `DATEDIFF` operator.
+
+2. Eliminate arithmetic operators against date fields.
+
+!!! warning "Practices to avoid"
+    ```sql
+        SELECT ObservationRequest.ReportId
+        FROM dbo.ObservationRequest ObservationRequest
+        WHERE > DATEDIFF(DAY,Observ ationRequest.AuthorisedDateTime,GETDATE())<=30;
+
+        SELECT ObservationRequest.ReportId
+        FROM dbo.ObservationRequest > ObservationRequest
+        WHERE CAST(ObservationRequest.AuthorisedDateTime AS DATE) > GETDATE()-30;
+    ```
+
+!!! example "Examples of good practice"
+    ```sql
+        SELECT COUNT(DISTINCT ObservationRequest.ReportId)
+        FROM dbo.ObservationRequest ObservationRequest
+        WHERE CAST(ObservationRequest.AuthorisedDateTime AS DATE) >= DATEADD(DAY,-30,CAST(GETDATE() AS > DATE));
+    ```
+
+## Stored procedures #1
+
+In this next example, we will step through a stored procedure making
+sure to:
+
+1. Qualify the procedure name with the schema.
+
+2. Add `BEGIN` and `END` statements.
+
+3. `SET NOCOUNT ON`
+
+4. Return a value.
+
+!!! warning "Practices to avoid"
+    ```sql
+        CREATE PROCEDURE prGetReportMasterId @Id BIGINT
+        AS
+            SELECT
+                Report.Id
+            , Report.MasterReportId
+            FROM
+                dbo.Report AS Report
+                WHERE Report.Id = @Id;
+
+        CREATE PROCEDURE dbo.prGetReportMasterId @Id BIGINT
+        AS
+            SELECT
+                Report.Id
+            , Report.MasterReportId
+            FROM
+                dbo.Report AS Report
+                WHERE Report.Id = @Id;
+
+        CREATE PROCEDURE dbo.prGetReportMasterId @Id BIGINT
+        AS
+        BEGIN
+            SELECT
+                Report.Id
+            , Report.MasterReportId
+            FROM
+                dbo.Report AS Report
+                WHERE Report.Id = @Id;
+        END;
+
+        CREATE PROCEDURE dbo.prGetReportMasterId @Id BIGINT
+        AS
+        BEGIN
+            SET NOCOUNT ON;
+            SELECT
+                Report.Id
+            , Report.MasterReportId
+            FROM
+                dbo.Report AS Report
+                WHERE Report.Id = @Id;
+        END;
+    ```
+
+!!! example "Examples of good practice"
+    ```sql
+        CREATE PROCEDURE dbo.prGetReportMasterId @Id BIGINT
+        AS
+        BEGIN
+            SET NOCOUNT ON;
+            SELECT
+                Report.Id
+            , Report.MasterReportId
+            FROM
+                dbo.Report AS Report
+                WHERE Report.Id = @Id;
+            RETURN 0;
+        END;
+    ```
+
+## Stored procedures #2
+
+In the following example, we will step through a stored procedure making
+sure to:
+
+1. Specify length for `VARCHAR` parameters.
+
+2. Specify columns for `INSERT` statements.
+
+3. `SET NOCOUNT ON`, `SET XACT_ABORT ON`
+
+4. Add implicit transaction using `BEGIN TRANSACTION` and `COMMIT`
+
+5. Add Error Handling using `TRY ... CATCH` blocks.
+
+!!! warning "Practices to avoid"
+    ```sql
+        CREATE PROCEDURE dbo.InsertReferenceDataValue
+              @ReferenceDataDomainId INT
+            , @Code                  VARCHAR
+            , @Rubric                VARCHAR
+            , @Active                BIT
+            , @ParentId              INT = NULL
+        AS
+        BEGIN
+            INSERT dbo.ReferenceDataValue
+            VALUES
+                (
+                    @ReferenceDataDomainId
+                    , @Code
+                    , @Rubric
+                    , GETDATE()
+                    , @Active
+                    , @ParentId
+                );
+        RETURN 0;
+        END;
+
+        CREATE PROCEDURE dbo.InsertReferenceDataValue
+              @ReferenceDataDomainId INT
+            , @Code                  VARCHAR(50)
+            , @Rubric                VARCHAR(200)
+            , @Active                BIT
+            , @ParentId              INT = NULL
+        AS
+        BEGIN
+            INSERT dbo.ReferenceDataValue
+            VALUES
+                (
+                    @ReferenceDataDomainId
+                    , @Code
+                    , @Rubric
+                    , GETDATE()
+                    , @Active
+                    , @ParentId
+                );
+        RETURN 0;
+        END;
+
+        CREATE PROCEDURE dbo.InsertReferenceDataValue
+              @ReferenceDataDomainId INT
+            , @Code                  VARCHAR(50)
+            , @Rubric                VARCHAR(200)
+            , @Active                BIT
+            , @ParentId              INT = NULL
+        AS
+        BEGIN
+            INSERT dbo.ReferenceDataValue
+                (
+                    Id
+                , ReferenceDataDomainId
+                , Code
+                , Rubric
+                , DateTimeCreated
+                , Active
+                , ParentId
+                )
+            VALUES
+                (
+                    @ReferenceDataDomainId
+                    , @Code
+                    , @Rubric
+                    , GETDATE()
+                    , @Active
+                    , @ParentId
+                );
+        RETURN 0;
+        END;
+
+        CREATE PROCEDURE dbo.InsertReferenceDataValue
+              @ReferenceDataDomainId INT
+            , @Code                  VARCHAR(50)
+            , @Rubric                VARCHAR(200)
+            , @Active                BIT
+            , @ParentId              INT = NULL
+        AS
+        BEGIN
+            SET NOCOUNT ON;
+            SET XACT_ABORT ON;
+            INSERT dbo.ReferenceDataValue
+                (
+                    Id
+                , ReferenceDataDomainId
+                , Code
+                , Rubric
+                , DateTimeCreated
+                , Active
+                , ParentId
+                )
+            VALUES
+                (
+                    @ReferenceDataDomainId
+                    , @Code
+                    , @Rubric
+                    , GETDATE()
+                    , @Active
+                    , @ParentId
+                );
+        RETURN 0;
+        END;
+        
+        CREATE PROCEDURE dbo.InsertReferenceDataValue
+              @ReferenceDataDomainId INT
+            , @Code                  VARCHAR(50)
+            , @Rubric                VARCHAR(200)
+            , @Active                BIT
+            , @ParentId              INT = NULL
+        AS
+        BEGIN
+            SET NOCOUNT ON;
+            SET XACT_ABORT ON;
+            BEGIN TRANSACTION
+            INSERT dbo.ReferenceDataValue
+                (
+                    Id
+                , ReferenceDataDomainId
+                , Code
+                , Rubric
+                , DateTimeCreated
+                , Active
+                , ParentId
+                )
+            VALUES
+                (
+                    @ReferenceDataDomainId
+                    , @Code
+                    , @Rubric
+                    , GETDATE()
+                    , @Active
+                    , @ParentId
+                );
+            COMMIT
+        RETURN 0;
+        END;    
+    ```
+
+!!! example "Examples of good practice"
+    ```sql
+        CREATE PROCEDURE dbo.InsertReferenceDataValue
+              @ReferenceDataDomainId INT
+            , @Code                  VARCHAR(50)
+            , @Rubric                VARCHAR(200)
+            , @Active                BIT
+            , @ParentId              INT = NULL
+        AS
+        BEGIN
+            SET NOCOUNT ON;
+            SET XACT_ABORT ON;
+            BEGIN TRY
+                BEGIN TRANSACTION
+                INSERT dbo.ReferenceDataValue
+                    (
+                        Id
+                    , ReferenceDataDomainId
+                    , Code
+                    , Rubric
+                    , DateTimeCreated
+                    , Active
+                    , ParentId
+                    )
+                VALUES
+                    (
+                        @ReferenceDataDomainId
+                        , @Code
+                        , @Rubric
+                        , GETDATE()
+                        , @Active
+                        , @ParentId
+                    );
+                COMMIT
+            END TRY
+            BEGIN CATCH
+                DECLARE @ErrorMsg VARCHAR(4000);
+                SET @ErrorMsg = ERROR_MESSAGE();
+                -- Rollback our transaction
+                IF @@TRANCOUNT>0
+                    ROLLBACK;
+                --Re-raise the error to our application;
+                RAISERROR(@ErrorMsg, 16, 1);
+            END CATCH;
+        RETURN 0;
+        END;
+    ```
+
+## Naming
+
+In our last example, we contrast a simple database query that does not
+conform to our rules with one that does. The conformant query assumes
+there is a constraint preventing any changes to the underlying database
+schema.
+
+The conformant query implements the following rules: -
+
+- Names are descriptive and singular.
+
+- Pascal Casing applied.
+
+- Prefixes and underscores removed.
+
+- All Keywords are uppercase.
+
+- Meaningful table alias name applied.
+
+- Columns qualified with Table alias and meaningful column alias
+    applied.
+
+- Meaningful column alias and name applied.
+
+- SQL Prompt formatting style rule applied.
+
+!!! warning "Practices to avoid"
+    ```sql
+        SELECT SubjectGivenName, SubjectFamilyName, [Hospital Ward]
+        FROM tblPatients WHERE ID = @int_ID
+        AND SubjectGivenName =  @str_param2;
+    ```
+
+!!! example "Examples of good practice"
+    ```sql
+        SELECT
+            Patient.SubjectGivenName AS FirstName
+            , Patient.SubjectFamilyName AS LastName
+            , Patient.[Hospital Ward] AS HospitalWard
+        FROM
+            dbo.tblPatients AS Patient
+        WHERE
+            Patient.ID = @PatientId
+            AND Patient.SubjectGivenName = @FirstName;
+    ```
+
+[^1]: <https://documentation.red-gate.com/codeanalysis/code-analysis-for-sql-server/style-rules/st010>

--- a/doc/t-sql-coding-standard/exceptions-prove-the-rule.md
+++ b/doc/t-sql-coding-standard/exceptions-prove-the-rule.md
@@ -1,0 +1,7 @@
+# Exceptions prove the rule
+
+As with most standards, there are occasions when it's unwise to follow
+"hard and fast" rules.
+
+Principal and Lead software developers have discretion to do so but this
+should be the exception rather than the rule.

--- a/doc/t-sql-coding-standard/follow-our-code-layout-rules.md
+++ b/doc/t-sql-coding-standard/follow-our-code-layout-rules.md
@@ -1,0 +1,27 @@
+# Follow our code layout rules
+
+These rules apply to decorative changes that affect whitespace such as
+tabs, spaces and line breaks. Nonetheless, it's important to adhere to a
+standard, to help others understand the intent of code.
+
+So, while SQL Prompt allows us to write code in a format, we find
+comfortable, we must always apply our standard styling rules[^1] before
+sharing code and checking it into source control.
+
+You **SHOULD** format and analyse your code using SQL Prompt before
+checking into source control.
+
+You **SHOULD** configure SQL Prompt with our rule. See [SQL Prompt
+configuration](sql-prompt-configuration.md) for help with using our
+standard SQL Prompt config files.
+
+!!! info "Further reading and information"
+    [The Basics of Good T-SQL Coding Style - Simple Talk (red-gate.com )](https://www.red-gate.com/simple-talk/databases/sql-server/t-sql-programming-sql-server/basics-good-t-sql-coding-style/)
+
+    [Beyond Formatting: Improving SQL Code using SQL Prompt Actions \| Redgate (red-gate.com )](https://www.red-gate.com/hub/product-learning/sql-prompt/beyond-formatting-improving-sql-code-using-sql-prompt-actions)
+
+    [The Redgate Guide to SQL Server Team-based Development \| Redgate (red-gate.com)](https://www.red-gate.com/library/the-redgate-guide-to-sql-server-team-based-development)
+
+    [Using multiple custom SQL formatting styles in SQL Prompt (red-gate .com)](https://www.red-gate.com/hub/product-learning/sql-prompt/using-multiple-custom-sql-formatting-styles-in-sql-prompt)
+
+[^1]: In this regard, SQL prompt is necessary to implement the standard

--- a/doc/t-sql-coding-standard/follow-our-naming-rules-see-also-table-design-rules.md
+++ b/doc/t-sql-coding-standard/follow-our-naming-rules-see-also-table-design-rules.md
@@ -1,0 +1,77 @@
+# Follow our naming rules (see also table design rules)
+
+You **SHOULD**:-
+
+- Use descriptive names, favouring readability over brevity.
+
+- Favour singular nouns over plurals for table names views and
+    scalars (columns, parameters and variables.) The use of a
+    collective name is best.
+
+- Use a mix of verbs and nouns in the present tense for functions
+    and stored procedure names[^1].
+
+- Use uppercase for all *Keywords, Built-in functions, built-in
+    datatypes* and *Global Variables*[^2].
+
+- Use Pascal Casing (with the first letter and each subsequent
+    concatenated word capitalized) consistently for all other
+    names[^3].
+
+- Use capitalization where common abbreviations[^4] are used.
+
+- Use prefixes and underscores for the following common naming
+    conventions (next page).
+
+You **SHOULD NOT**:-
+
+- Rely on system generated named objects such as constraints or
+    indexes.
+
+- Use abbreviations, spaces, or non-standard characters and reserved
+    words. Doing so avoids the need to use square brackets.
+
+- Prefix stored procedures with sp\_ Doing so impedes
+    performance because SQL Server searches the master database first.
+
+- Use prefixes (Hungarian notation), suffixes and underscores except
+    where specific naming conventions exist (see the next page.)
+
+| **Prefix** | **Usage** | **Example** | **Notes** |
+| --- | --- | --- | --- |
+| **pr**| Stored Procedure | pr GetReportIDAndIdentifiers | Optional, but use must be consistent within a database |
+| **fn**| F unction | fnSaveNewPassword |  |
+| **tr**| Trigger | trAuditChangeToNHSNumber |  |
+| **CIX**| Clustered Index | CIX_Report_Id | Table name and indexes are also separated by an underscore. |
+| **PK**| Primary Key | PK_Report | Table name |
+| **IX**| Index | IX_Report_SubjectDoBFamilyNameGivenNameId_includes | Table name and indexes are also separated by an underscore. Use "includes" showing the index has included columns[^5]. |
+| **FK**| Foreign Key | FK_ReferenceDataValue_ID_PlacerID | Table name, referenced field(s) and referencing field(s) also separated by an underscore |
+| **DF**| Default constraint |  |  |
+| **CK**| Check constraint |  |  |
+| **UQ**| Unique constraint |  |  |
+
+!!! info "Further reading and information"
+    [Publicly Available Standards (iso.org)](https://standards.iso.org/ittf/PubliclyAvailableStandards/c060341_ISO_IEC_11179-5_2015.zip)
+
+    [Reserved Keywords (Transact-SQL) - SQL Server \| Microsoft Learn](https://learn.microsoft.com/en-gb/sql/t-sql/language-elements/reserved-keywords-transact-sql?view=sql-server-ver16)
+
+    [The 9 Most Common Database Design Errors \| Vertabelo Database Modeler](https://vertabelo.com/blog/the-9-most-common-database-design-errors/) (No. #4)
+
+    [Ten Common Database Design Mistakes - Simple Talk (red-gate.com)](https://www.red-gate.com/simple-talk/databases/sql-server/database-administration-sql-server/ten-common-database-design-mistakes/)
+
+[^1]: But beware of situations where this is counterproductive. For
+    example, having many procedures prefixed with 'Get' makes any
+    specific stored procedure difficult to spot. See the section
+    '[Exceptions prove the rule'](exceptions-prove-the-rule.md).
+
+[^2]: This rule raised the concern that we could end up with differing
+    coding standards based on language and technology and we will.
+    However, SQL is a set-based language -- it's acceptable that
+    different rules apply.
+
+[^3]: Be aware that Redgate SQL prompts adds aliases in lower case
+    based on the leading letters in a camel case table name.
+
+[^4]: Use abbreviations only when there can be no doubt as to their meaning.
+
+[^5]: Included columns prevent a key-lookup in the query plan and so aid performance.

--- a/doc/t-sql-coding-standard/follow-our-table-rules-columns-and-datatypes.md
+++ b/doc/t-sql-coding-standard/follow-our-table-rules-columns-and-datatypes.md
@@ -1,0 +1,42 @@
+# Follow our table rules: columns and datatypes
+
+You **SHOULD**:-
+
+- Specify the nullability on columns.
+
+- Define column data types (such as `VARCHAR` and `CHAR`)
+    appropriately.
+
+- Specify the length of a character column, even if you want it to
+    be one. This rule applies when also declaring or casting variable
+    datatypes.
+
+- Use fixed-length datatypes rather than declaring variables as
+    variable length of length 1 or 2.
+
+- Include the precision and scale (when supported) when specifying
+    numeric types. This prevents you being bound to the default
+    values.
+
+- Follow good database design practices. And if you consider yourself
+    an 'Accidental DBA' be sure to read the 'Accidental DBA guide'!
+
+You **SHOULD NOT**:-
+
+- Use the `CHAR` or `NCHAR` data type for columns that permit
+    `NULL` values.
+
+- Use `VARCHAR(MAX)` when unnecessary.
+
+- Use the `TEXT` or `NTEXT` datatypes.
+
+- Declare variables without a datatype length. For example, `DECLARE`
+    `@MyVar VARCHAR;` is to be avoided.
+
+- Use inappropriate datatypes. For example, storing numbers or dates
+    as `VARCHAR`.
+
+!!! info "Further reading and information"
+    [How to Get NULLs Horribly Wrong in SQL Server - Simple Talk (red-gate.com)](https://www.red-gate.com/simple-talk/databases/sql-server/t-sql-programming-sql-server/how-to-get-nulls-horribly-wrong-in-sql-server/)
+
+    [Troubleshooting SQL Server: A Guide for Accidental DBAs \| Redgate (red-gate.com)](https://www.red-gate.com/library/troubleshooting-sql-server-a-guide-for-accidental-dbas)

--- a/doc/t-sql-coding-standard/follow-out-table-design-rules-schemes-and-indexes.md
+++ b/doc/t-sql-coding-standard/follow-out-table-design-rules-schemes-and-indexes.md
@@ -1,0 +1,69 @@
+# Follow out table design rules: schemes and indexes
+
+You **SHOULD**:-
+
+- Specify a schema when creating a table from a script.
+
+- Ensure that each Primary Key comprises the column(s) that uniquely
+    identify each row in the table.
+
+- Include the index type (clustered or non-clustered) when defining
+    the Primary Key.
+
+- Choose the most suitable column(s) for a clustered index[^1].
+
+- Use the Primary Key as the clustered index (it's the default and
+    usually the prime candidate but not always!)
+
+- Include the table name and the indexed fields (ordered as specified
+    in the index definition) in the index name.
+
+- Use the `INCLUDE` clause of non-clustered indexes to cover
+    columns returned in select clauses or used to join other tables.
+    This prevents the query optimizer having to perform key-lookup
+    operations.
+
+- Learn how the index column order in a multi-column index affects
+    performance.
+
+- Define any necessary Foreign Key constraints on your tables.
+
+- Include the table name, referenced field(s) and referencing field(s)
+    in the Foreign Key name.
+
+- Create an index on a foreign key's child table columns.
+
+- Review index reports[^2] with your support team. Remember that
+    in high availability environments, such as an *Always On
+    Availability Group*, the index usage is different on writable and
+    read-only nodes.
+
+You **SHOULD NOT**:-
+
+- Create tables without defining a Primary Key or Clustered Index.
+
+- Use GUIDs (e.g. `UNIQUEIDENTIFIER`) for clustered keys, especially
+    where the primary key is defined as the clustered index. This can
+    result in performance problems. Rather use an alternative datatype,
+    for example `BIGINT`, or use the function `NEWSEQUENTIALID()` to generate
+    a GUID. This reduces fragmentation.
+
+- Use a column that is frequently updated in a clustered index.
+
+- Create duplicate indexes. Remember, column order in the `INCLUDE`
+    clause is *not* significant.
+
+!!! tip "Practical tips"
+    **WCP (Welsh Clinical Portal) -- Missing Microbiology Results**
+
+    In 2015, a database reference table allowing duplicates contributed to the problem of missing electronic microbiology results.
+
+!!! info "Further reading and information"
+    [SQL Server Best Practices -- Implementation of Database Object Schemas \| Microsoft Learn](https://learn.microsoft.com/en-gb/previous-versions/sql/sql-server-2008/dd283095(v=sql.100))
+
+    [Handling Constraint Violations and Errors in SQL Server - Simple Talk (red-gate.com)](https://www.red-gate.com/simple-talk/databases/sql-server/t-sql-programming-sql-server/handling-constraint-violations-and-errors-in-sql-server/)
+
+[^1]: Based on your queries and performance considerations
+
+[^2]: For example [Brent Ozar Blitz Index](https://www.brentozar.com/blitzindex/) makes use of SQL
+    Server's Missing Index Dynamic Management Views (DMVs)

--- a/doc/t-sql-coding-standard/follow-these-rules-when-using-an-object-relational-mapper-orm.md
+++ b/doc/t-sql-coding-standard/follow-these-rules-when-using-an-object-relational-mapper-orm.md
@@ -1,0 +1,18 @@
+# Follow these rules when using an object relational mapper (orm)
+
+You **MUST** consider this standard when using an Object-relational
+mapping (ORM) tool such as Microsoft's Entity Framework. And to achieve
+the best performance from your database: -
+
+- You **SHOULD** use stored procedures for data access. Support tools
+    (such as those used for SQL Migrations) cannot identify issues with
+    code that is not stored in the database.
+
+- You **SHOULD** follow good practice if working with ORMS. See ORM
+    tips, below.
+
+- You **SHOULD NOT** use Entity Framework's code first approach to
+    create and maintain database schemas.
+
+!!! info "Further reading and information"
+    [45 Database Performance Tips for Developers \| Redgate (red-gate.com)](https://www.red-gate.com/library/45-database-performance-tips-for-developers) ORM Tips (pages 4 & 5)

--- a/doc/t-sql-coding-standard/general-good-practice.md
+++ b/doc/t-sql-coding-standard/general-good-practice.md
@@ -1,0 +1,65 @@
+# General good practice
+
+You **MUST** store T-SQL scripts and database code in source control as a
+'single source of truth.'
+
+You **SHOULD**: -
+
+- Check your SQL application is performant. You may find your
+    support team or Database Administrator (DBA) may be able to help.
+
+- Review your code to address any issues, such as performance and
+    security considerations.
+
+- Share code using code snippets and a common repository.
+
+- Conform to ANSI standards wherever possible.
+
+- Prefer `CAST` to `CONVERT`
+
+- Prefer `SET` to `SELECT` when assigning variables.
+
+- Prefer `COALESCE` to `ISNULL`
+
+- Format and analyse your code using SQL Prompt before checking into
+    source control.
+
+- Configure SQL Prompt using our config files. See [SQL Prompt
+    configuration](sql-prompt-configuration.md) for help.
+
+You **SHOULD NOT**:-
+
+- Use deprecated features.
+
+- Use dynamic SQL. If you cannot avoid this then call it using
+    sp_executesql rather than the `EXECUTE` statement.
+
+- Expect your DBA to performance tune your queries but do ask them for
+    advice. Particularly what tools to use.
+
+- Use undocumented stored procedures.
+
+- Create objects that flout the single responsibility pattern. Such
+    as: -
+
+1. Entity-attribute-value tables.
+
+2. Generic stored procedures with no specific (or multiple) use cases.
+
+3. Using a single table to hold all lookup values, metadata, and domain or reference data.
+
+!!! tip "Practical tips"
+    **WPRS -- Prioritisation incident**
+
+    In 2016, a failure to run SQL code analysis checks and deploy from source control prevented referrals including those for urgent suspected cancer being actioned.
+
+    WPRS -- WPAS (Welsh Patient Administration System) delayed Urgent Suspected Cancer referral.
+
+    In 2017, a failure to deploy the correct stored procedure led to a delay in referring a patient with urgent suspected cancer.
+
+!!! info "Further reading and information"
+    [How to Think Like the SQL Server Engine - Brent Ozar Unlimited®](https://www.brentozar.com/training/think-like-sql-server-engine/)
+
+    [SQL Code Smells - Simple Talk (red-gate.com)](https://www.red-gate.com/simple-talk/databases/sql-server/t-sql-programming-sql-server/sql-code-smells/)
+
+    [Discontinued database engine functionality - SQL Server \| Microsoft Learn](https://learn.microsoft.com/en-gb/sql/database-engine/discontinued-database-engine-functionality-in-sql-server?view=sql-server-ver16)

--- a/doc/t-sql-coding-standard/good-practice-checklists.md
+++ b/doc/t-sql-coding-standard/good-practice-checklists.md
@@ -1,0 +1,16 @@
+# Good practice checklists
+
+Use this checklist to demonstrate you follow our coding standards.
+
+We cross-reference each checklist item to a relevant section in our
+standards and guides; Exceptions are noted where they may apply.
+
+## 9.1 general good practice
+
+| **Item** |  |  | **Guide or standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 1 | You avoid placing business logic in the database | ☐ | *T-SQL coding standard, [7.1](avoid-using-t-sql-to-execute-business-logic.md)* | This is a general rule. But there may be times when there are good reasons not to follow it. |
+| 2 | You follow the coding conventions described in this standard | ☐ | *T-SQL coding standard, All* |  |
+| 3 | You keep T-SQL scripts and database code in source control | ☐ | *T-SQL coding standard, [7.3](general-good-practice.md)* |  |
+| 5 | You analyse T-SQL against Redgate code analysis rules | ☐ | *T-SQL coding standard, [7.6](apply-code-analysis-rules.md)* |  |
+| 6 | You format T-SQL using our common configuration settings | ☐ | *T-SQL coding standard, [7.20](follow-our-code-layout-rules.md)* |  |

--- a/doc/t-sql-coding-standard/handling-exceptions.md
+++ b/doc/t-sql-coding-standard/handling-exceptions.md
@@ -1,0 +1,16 @@
+# Handling exceptions
+
+You **SHOULD**:-
+
+- Manage exceptions in each stored procedure, but you **SHOULD NOT**
+    mask the error from the calling application.
+
+- Use the `TRY ... CATCH` construct to handle errors in T-SQL.
+
+- Use a log table to record errors handled. It helps with support
+    and maintenance.
+
+- Favour `THROW` over `RAISERROR` wherever possible (i.e. in database
+    compatibility SQL 2012 and later.)
+
+- Return a result code.

--- a/doc/t-sql-coding-standard/introduction.md
+++ b/doc/t-sql-coding-standard/introduction.md
@@ -1,0 +1,50 @@
+# Introduction
+
+## Purpose
+
+- Describes the Application Development and Support Directorate's
+    coding standard for writing T-SQL.
+
+- Demonstrates the importance of following good practice by quoting
+    examples of working practices that have contributed to clinical
+    incidents.
+
+## Scope
+
+Software Developers have a responsibility to follow this guide.
+
+- Developers not using T-SQL may need to adjust to their version of
+    SQL or consider the need for a local coding standard.
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! example "Redgate SQL Prompt"
+    Indicates that this rule can be implemented using Redgate SQL Prompt
+
+!!! info "Further reading and information"
+    Note Links to SQL Server content in Microsoft Learn© default to SQL Server 2022.
+    Use its version selector to tailor the website for other versions.
+
+## The need for guidance
+
+Use this standard to -
+
+- write code in a consistent way. So that those who read it may draw
+    on previous experience to understand it more quickly.
+
+- produce software that is based on good practice, is maintainable,
+    performant and secure.

--- a/doc/t-sql-coding-standard/permissions.md
+++ b/doc/t-sql-coding-standard/permissions.md
@@ -1,0 +1,23 @@
+# Permissions
+
+You ****SHOULD**:-
+
+- Define database roles for the specific type of database access
+    required.
+
+- Grant database object permissions *only* to database roles.
+
+- Grant database access to Active Directory groups and service
+    accounts via membership of database roles.
+
+- Record information about the accounts you create and the permissions
+    you assign them in each environment.
+
+You **SHOULD NOT**:-
+
+- Instinctively grant database owner (dbo) permissions.
+
+- Use SQL Server logins, unless working with a 3rd party application
+    that specifically requires their use.
+
+- Grant database access to individual user accounts.

--- a/doc/t-sql-coding-standard/sql-prompt-configuration.md
+++ b/doc/t-sql-coding-standard/sql-prompt-configuration.md
@@ -1,0 +1,102 @@
+# SQL prompt configuration
+
+## SQL prompt settings file
+
+### How to import the settings
+
+1. Download the *`NWIS_STANDARD_SQLPROMPT_SETTINGS`* file to a local
+    directory.
+
+> You can find the file from the *Software Development Standards* git
+> repo under the *Software Development Standards* project on Application
+> Development & Support's Azure DevOps instance.
+
+1. Open SQL Server Management Studio with Redgate SQL Prompt v9 or
+    later installed and choose ***SQL Prompt > Options.***
+
+> Select ***Import*** to load the
+> *`NWIS_STANDARD_SQLPROMPT_SETTINGS.settings`* file.
+
+### The settings file explained
+
+| **Suggestions** |  |
+| --- | --- |
+| Behaviour | Uses default settings |
+| Connections | Uses default settings with the following exceptions: Unchecks the ***Load suggestions for linked servers*** & ***Load suggestions for synonyms*** options. Note: This is done to improve performance. Specifying the databases to  load may further improve performance, but this will vary between teams. |
+| Join Conditions | Unchecks ***Columns with matching names (not case-sensitive)***. Checks ***Individual columns in multiple-column foreign keys*** |
+| Snippets | Uses default settings |
+| Warnings & highlighting | Checks all options other than '*Show warnings for DROP statements*' |
+
+| **Inserted Code** |  |
+| --- | --- |
+| Objects and statements | Uses default settings |
+| Qualification | Checks all options |
+| Aliases | Checks **Assign aliases**. Note: Custom aliases should be used to provide consistency across an application, but these cannot be defined here. |
+| Special characters | Uses default settings |
+
+| **Format** |  |
+| --- | --- |
+| Styles | For formatting styles see [SQL Prompt formatting style file](#sql-prompt-formatting-style-file). In addition to default settings checks. ***Expand wildcards***, ***Qualify object names***, ***Insert semicolons***, ***Apply column alias style***, ***Column AS alias***, ***Add/remove square brackets***, ***Remove unnecessary brackets***, ***Add/remove AS keyword on alias definition for tables and views***, ***Add AS keyword*** |
+
+| **Tabs** |  |
+| --- | --- |
+| History | Sets ***Maximum number of tabs to restore:*** to **5**. Unchecks ***Automatically reconnect restored tabs*** |
+| Color | Uses default settings. Note: Colour can be used to differentiate environments. However, separate credentials (e.g. `NatTd`, `GIGNWI`) should be used to connect to development and production environments; these accounts can support their own SQL Prompt settings. |
+
+## SQL prompt formatting style file
+
+### How to import the style
+
+1. Download the *`NWIS_STANDARD_SQLPROMPT_SETTINGS`* file to a local
+    directory.
+
+> You can find the file from the *Software Development Standards* git
+> repo under the *Software Development Standards* project on Application
+> Development & Support's Azure DevOps instance.
+
+1. You have a choice of two versions. If using SQL Prompt v10.5 or
+    later, choose the newer *`.json`* file extension. If using an earlier
+    version, choose the *`.sqlpromptstylev2`* file type.
+
+1. With the correct style file selected, save it to "*`<Insert Drive Letter>:\Users\<Insert Test-Dev-NADEX-ID>\AppData\Local\Red Gate\SQL Prompt <Version>\StylesV2`" or *
+    "`<Insert Drive Letter>:\Users\<Insert Test-Dev-NADEX-ID>\AppData\Local\Red Gate\SQL Prompt <Version>\Styles`*[^1]
+
+1. Open SQL Server Management Studio with Redgate SQL Prompt v9 or
+    later installed.
+
+1. From the menu choose ***SQL Prompt > Active Styles > Edit Formatting Styles***
+
+1. Under ***Your styles*** (top right), select the vertical ellipsis
+    next to ***NWIS_Custom style indented, commas before*** and choose
+    ***Set as active.***
+
+### The style file explained
+
+Uses Redgate's ***Indented defaults*** as its base style with the
+following customisations applied: -
+
+| **GLOBAL** |  |
+| --- | --- |
+| Whitespace | ***Wrapping***: Sets ***Wrap lines longer than*** to **160 characters** |
+| Lists | ***Commas***: Checks ***Place commas before items***. Sets ***Comma alignment*** to **Before item**. Checks ***Add a space after comma*** |
+| Casing | Sets ***Global variables*** to **UPPERCASE** |
+
+| **EXPRESSIONS** |  |
+| --- | --- |
+| CASE | Unchecks ***Place expressions on new line***. ***WHEN***: Sets ***Place first WHEN on new line*** to **If there's an input expression**; Sets ***WHEN alignment*** to **Indented from CASE**. **THEN expressions**: Unchecks ***Place THEN on new line***. **ELSE**: Checks ***Place ELSE on new line***; Checks ***Align ELSE to WHEN***. **END**: Checks ***Place END on new line***; Sets ***End alignment*** to *To CASE*. **Short CASE expressions**: Unchecks ***Collapse CASE expressions shorter than n characters*** |
+
+### Notes & explanation
+
+Commas before: -
+
+- clearly define a new column.
+
+- help identify when a comma is missing.
+
+- make it easier to comment out additional fields during development.
+
+Indentation aids readability. However, long expressions may appear
+distorted when wrapped. See the section [Exceptions prove the
+rule](exceptions-prove-the-rule.md).
+
+[^1]: E.g. `D:\\Users\\NatTD_ge080206\\*AppData\\Local\\Red Gate\\SQL Prompt 9\\StylesV2*`

--- a/doc/t-sql-coding-standard/stored-procedures.md
+++ b/doc/t-sql-coding-standard/stored-procedures.md
@@ -1,0 +1,75 @@
+# Stored procedures
+
+You **SHOULD: -**
+
+- Use meaningful names to indicate the purpose of procedures &
+    parameters. Be verbose if needed.
+
+- Match parameter datatypes to the underlying data to avoid implicit
+    conversion.
+
+- Include a comment header to indicate the procedure's purpose and
+    use. Include an example call if possible.
+
+- Enclose procedures with `BEGIN END` blocks after the `AS`
+    keyword.
+
+- Add the `SET NOCOUNT ON` statement before any Data Manipulation
+    Language statements unless you have good reason for not doing so.
+
+- Use `SET XACT_ABORT ON`. It terminates and rollbacks the entire
+    transaction when a T-SQL statement raises a run-time error.
+
+- Declare variables, table variables and temp tables at the start of
+    a procedure[^1].
+
+- Use `BEGIN` and `END` after `IF`, even if only one statement
+    is covered. This makes the code clearer and avoids errors if further
+    statements are added to the `IF` block later.
+
+- Use table variables for transitory tables with *less* than 1000
+    rows.
+
+- Use temporary tables for transitory tables with *more* than 1000
+    rows.
+
+- Use explicit transactions when updating data.
+
+- Use SavePoints within a transaction. The use of SavePoint can
+    allow you to rollback a series of statements within a transaction.
+
+- Pass parameters explicitly to Stored Procedures and `EXECUTE`
+    statements wherever possible.
+
+You **SHOULD NOT**:-
+
+- Set the `ANSI_NULLS` option. It should normally be set to `ON` and
+    is deprecated by Microsoft and not supported for certain indexes.
+
+- Set the `QUOTED_IDENTIFIER` option. It has no effect and should
+    normally be set to `ON`.
+
+- Declare **variables** you never use.
+
+- Use `CURSOR` *s* and `WHILE` clauses.
+
+- Use Table Variables, Temporary Tables, Common Table Expressions and
+    Subqueries without understanding their impact on performance.
+
+- Use nested transactions. A `ROLLBACK` of a nested transaction
+    can affect more than just the statements executed.
+
+- Return multiple result sets.
+
+- Supply stored procedures with a wide range of data parameters. SQL
+    Server compiles these to a single query plan.
+
+!!! info "Further reading and information"
+    [Discontinued database engine functionality - SQL Server \| Microsoft Learn](https://learn.microsoft.com/en-gb/sql/database-engine/discontinued-database-engine-functionality-in-sql-server?view=sql-server-ver16)
+
+    [Temporary Tables in SQL Server - Simple Talk (red-gate.com )](https://www.red-gate.com/simple-talk/databases/sql-server/t-sql-programming-sql-server/temporary-tables-in-sql-server/)
+
+[^1]: **Note**: This is contrary to the general coding standards. But
+    Redgate discourages interweaving Data Definition Language (e.g.
+    `CREATE TABLE`) and Data Manipulation Language statements (e.g.
+    `SELECT`).

--- a/doc/t-sql-coding-standard/top-n-and-order-by.md
+++ b/doc/t-sql-coding-standard/top-n-and-order-by.md
@@ -1,0 +1,18 @@
+# Top (n) and order by
+
+You **SHOULD** try to order result sets in the application layer.
+Because qualifying statements with `ORDER BY` are expensive in SQL!
+
+You **SHOULD NOT**:-
+
+- Use `SET ROWCOUNT`. Prefer the `TOP(N)` syntax of the `SELECT`
+    statement.
+
+- Use `TOP` in a `SELECT` list without using `ORDER BY`
+     It's clear and returns consistent results.
+
+- Use constants in an `ORDER BY` clause; It's deprecated and makes
+    code hard to read.
+
+!!! info "Further reading and information"
+    [Avoid using constants in an ORDER BY clause \| Redgate (red-gate.com)](https://www.red-gate.com/hub/product-learning/sql-prompt/avoid-using-constants-in-an-order-by-clause)

--- a/doc/t-sql-coding-standard/views.md
+++ b/doc/t-sql-coding-standard/views.md
@@ -1,0 +1,16 @@
+# Views
+
+You **SHOULD NOT**:-
+
+- Define nested views. Views that call or join to other views can
+    result in complex query plans.
+
+- Use wildcards in view definitions as it can result in unexpected
+    behaviour[^1].
+
+- Use `ORDER BY` in views. Use the `ORDER BY` clause only in the outermost
+    query.
+
+[^1]: This is caused because SQL Server caches the view's output
+    metadata but doesn't update the cache when underlying objects
+    change.

--- a/doc/t-sql-coding-standard/working-with-sql-server-agent.md
+++ b/doc/t-sql-coding-standard/working-with-sql-server-agent.md
@@ -1,0 +1,20 @@
+# Working with SQL server agent
+
+You **SHOULD**:-
+
+- Define job steps that call stored procedures.
+
+- Make sure jobs exist across all your high-availability SQL instances
+    (e.g., both side of the mirror, availability group nodes.)
+
+- Add an initial step to jobs on mirrors to allow the job to stop with
+    a warning rather than error.
+
+- Make use of the job categories
+
+- Use job categories or the description field to track temporarily
+    disabled and retired jobs.
+
+You **SHOULD NOT** define job steps with ad-hoc SQL; It hides
+application logic, and you are unable to manage it using SQL Source
+Control.

--- a/doc/t-sql-coding-standard/working-with-transactions.md
+++ b/doc/t-sql-coding-standard/working-with-transactions.md
@@ -1,0 +1,22 @@
+# Working with transactions
+
+You **SHOULD** pair each `BEGIN` `TRANSACTION` with a `COMMIT` **or**
+`ROLLBACK` `TRANSACTION` (and vice versa.) Open transactions can cause
+applications to fail if left unchecked.
+
+You **SHOULD NOT**:-
+
+- Perform cross database transactions even where SQL Server supports
+    them.
+
+- Perform cross server queries (using linked servers or `OPENQUERY`[^1].)
+
+- Perform cross database queries in mirrored environments. They will
+    fail should database failover occur[^2].
+
+!!! info "Further reading and information"
+    [Transactions: availability groups & database mirroring - SQL Server Always On \| Microsoft Learn](https://learn.microsoft.com/en-GB/sql/database-engine/availability-groups/windows/transactions-always-on-availability-and-database-mirroring?view=sql-server-ver16)
+
+[^1]: This should be resolved in the application design.
+
+[^2]: Although you may consider this an acceptable risk.

--- a/doc/t-sql-coding-standard/working-with-triggers.md
+++ b/doc/t-sql-coding-standard/working-with-triggers.md
@@ -1,0 +1,12 @@
+# Working with triggers
+
+You **SHOULD NOT**:-
+
+- Use triggers. They can affect performance and hide business logic.
+    Consider moving the required logic to another part of the
+    application. It makes support and maintenance easier!
+
+- Return data from a trigger using either `SELECT` or `PRINT`.
+
+!!! info "Further reading and information"
+    [Triggers: Threat or Menace? - Simple Talk (red-gate.com)](https://www.red-gate.com/simple-talk/databases/sql-server/t-sql-programming-sql-server/triggers-threat-menace/)

--- a/doc/t-sql-coding-standard/working-with-user-defined-functions-udf.md
+++ b/doc/t-sql-coding-standard/working-with-user-defined-functions-udf.md
@@ -1,0 +1,22 @@
+# Working with user defined functions (UDF)
+
+You **SHOULD**:-
+
+- Use inline table valued functions instead of scalar functions
+    where possible.
+
+- Use WITH SCHEMABINDING for non-data accessing scalar user
+    defined functions. It forces SQL server to check data access is
+    occurring at design time. Thus, preventing the need to do so during
+    execution.
+
+You **SHOULD NOT**:-
+
+- Use multi-statement table valued functions; these can impede
+    performance.
+
+- Use side-effecting operators within a user defined function, for
+    example `SELECT`, `PRINT`, `INSERT`, `UPDATE`, `TRY`, `CATCH`
+
+!!! info "Further reading and information"
+    [TSQL User-Defined Functions: Ten Questions You Were Too Shy to Ask - Simple Talk (red-gate.com)](https://www.red-gate.com/simple-talk/databases/sql-server/learn/tsql-user-defined-functions-ten-questions-you-were-too-shy-to-ask/)

--- a/doc/t-sql-coding-standard/xml-and-json.md
+++ b/doc/t-sql-coding-standard/xml-and-json.md
@@ -1,0 +1,15 @@
+# XML and JSON
+
+You **SHOULD** use SQL Server XML and JSON functions & methods[^1] to
+build and consume XML and JSON data.
+
+You **SHOULD NOT**:-
+
+- Build XML or JSON by concatenating strings. The loop construct
+    hinders performance and can provide data in an invalid data format.
+
+- Use XML or JSON data type methods and functions in a `WHERE`
+    or `JOIN` clause, except when working with small result sets in
+    a temporary table or table variable.
+
+[^1]: Available in SQL Server 2016 onwards

--- a/doc/test-summary-report/characteristics-of-a-good-test-summary-report.md
+++ b/doc/test-summary-report/characteristics-of-a-good-test-summary-report.md
@@ -1,0 +1,19 @@
+# Characteristics of a good test summary report
+
+A Test Summary Report **SHOULD** have the following characteristics: -
+
+|     |     |
+| --- | --- |
+| **SHORT:** | As a rule of thumb, aim for no more than 8 -- 11 pages. |
+| **CLEAR:** | Information should be clear. Read DHCW's [writing checklist](https://nhswales365.sharepoint.com/sites/DHCW-Intranet/SitePages/Writing-style-guide.aspx) for tips. |
+| **PRECISE:** | The information, though concise, should not be abstract as this will not help the reader draw clear conclusions from it. |
+| **CONSISTENT:** | While content will differ, each report **SHOULD** use the same template. |
+
+The remainder of this guide provides rules for drafting a report, using
+the template.
+
+!!! tip "Practical tips"
+    SDS-TEM-5 replaces the previous Test Summary Report and Test Certificate templates.
+
+    The Test Certificate has been retired with this guide's publication, and
+    Test Certificates **SHOULD** no longer be produced.

--- a/doc/test-summary-report/cover-page.md
+++ b/doc/test-summary-report/cover-page.md
@@ -1,0 +1,50 @@
+# Cover page
+
+The report's cover page **MUST** contain the following elements: -
+
+## Heading #1: "*digital health and care wales*"
+
+## Heading #2: name and version of the system under test
+
+You **SHOULD** include: -
+
+- The acronym (in parentheses) if you intend to use it in the report.
+
+- The version number, if applicable, prefixed with a 'v' for version
+    or 'b' for build number.
+
+## Heading #3: name of module or component
+
+Where appropriate you **SHOULD** include the name of the module or
+component.
+
+## Heading #4: "test summary report"
+
+## Heading #5: test phase
+
+You **SHOULD** choose an appropriate value from those listed on pages 26
+-- 30 of the Test Framework.
+
+## Heading #6: status
+
+This reflects the status of the document and **MUST** be 'Draft',
+'Draft-Update' or 'Issued'.
+
+!!! example "Examples of good practice"
+    Welsh Immunisation System (WIS) v4.3.0.0
+
+    Spring Boosters Campaign
+
+    Test Summary Report
+
+    Systems Integration Testing
+
+    Draft
+
+    6th March 2024
+
+## Footer: filename
+
+The Template's footer was inserted as Quick Parts -\> Fields -\>
+FileName. When you save the first copy of the report, right-click the
+footer and choose 'Update Field' to update the [filename](filename.md).

--- a/doc/test-summary-report/document-location.md
+++ b/doc/test-summary-report/document-location.md
@@ -1,0 +1,3 @@
+# Document location
+
+Document Location **MUST** be a hyperlink to the original document.

--- a/doc/test-summary-report/example-reports.md
+++ b/doc/test-summary-report/example-reports.md
@@ -1,0 +1,5 @@
+# Example reports
+
+You can find example reports from [Guides and standards (sharepoint.com)](https://nhswales365.sharepoint.com/sites/DHC_SD/SitePages/Guides-and-Standards.aspx)
+There might be slight variations in content and format compared to this
+template, but they are a helpful starting point.

--- a/doc/test-summary-report/exceptions-prove-the-rule.md
+++ b/doc/test-summary-report/exceptions-prove-the-rule.md
@@ -1,0 +1,9 @@
+# Exceptions prove the rule
+
+While this Test Summary Report template is designed to be suitable for
+most situations, there may be cases where altering the format is
+necessary and justifiable. These changes should be made only when they
+add significant value for the reader.
+
+However, it is important to maintain the integrity of the template, and
+changes **SHOULD NOT** be made casually.

--- a/doc/test-summary-report/filename.md
+++ b/doc/test-summary-report/filename.md
@@ -1,0 +1,11 @@
+# Filename
+
+The filename **SHOULD** be in the following format: -
+
+Test Summary Report-<*Name of System Under Test*\>-<*Module or
+Component Name*\>-<*Version or Build number*\>
+
+!!! example "Examples of good practice"
+    Test Summary Report-Welsh Immunisation System WIS-Spring Boosters Campaign 2024-v4.3.0.0.docx
+
+    Test Summary Report-NHS Wales App-Public Beta-v1.0.0.docx

--- a/doc/test-summary-report/further-metrics.md
+++ b/doc/test-summary-report/further-metrics.md
@@ -1,0 +1,5 @@
+# Further metrics
+
+You **MAY** include additional metrics from sources like Extent Reports
+or Azure DevOps dashboards to provide a more comprehensive perspective
+on the testing process.

--- a/doc/test-summary-report/introduction.md
+++ b/doc/test-summary-report/introduction.md
@@ -1,0 +1,83 @@
+# Introduction
+
+## Purpose
+
+A Test Summary Report tells readers whether your software needs
+corrective action, can proceed to the next stage or is ready for
+release. So it **SHOULD** provide a clear summary of the test process,
+results, and key metrics.
+
+This document instructs you on how to write a Test Summary Report. It is
+guided by the ISO 29119-3:2013[^1] standard for writing a Test
+Completion Report, although the headings used in the Test Summary Report
+template vary.
+
+When you are ready to start, base your report on the SDS-TEM-5 Test
+Summary Report template.
+
+## Scope
+
+### In-scope
+
+- This guide **SHOULD** be followed by anyone asked to submit a Test
+    Summary Report to the Welsh Informatics Assurance Group.
+
+### Out-of-scope
+
+- Other reports such as Test Progress and Test Defect reports are
+    out-of-scope.
+
+## Roles & responsibilities
+
+A Test Summary Report: -
+
+- **SHOULD** be written and signed by a *Test Analyst* or person with
+    equivalent knowledge, skills and experience. If your circumstances
+    differ, please contact the document author.
+
+- **MUST** be acknowledged as reviewed and signed as approved by a
+    *Lead Test Analyst*, *Test Team Principal* or person with equivalent
+    knowledge, skills and experience.
+
+- **MUST** be signed as approved by at least one of the following: -
+
+  - Product Specialist or person acting in that capacity.
+
+  - Application or Product Manager.
+
+  - A representative of a suitable Assurance Group or Project/Programme Board.
+
+## References
+
+| INDEX NUMBER | DOCUMENT NAME |
+| --- | --- |
+| N/A | [RFC 2119: RFC Keywords (ietf.org)](https://www.ietf.org/rfc/rfc2119.txt) |
+| N/A | [DHCW Brand Guidelines Nov 2023.pdf](https://nhswales365.sharepoint.com/:b:/r/sites/DHCW_CORP_Graphics/DHCW%20New%20Brand%20Guide/DHCWBrandGuidelines-Nov2023.pdf?csf=1&web=1&e=KDlOnc) |
+| N/A | Test framework |
+| N/A | BS ISO/IEC/IEEE 29119-3:2013 Software and systems engineering --- Software testing Part 3: Test documentation |
+| SDS-TEM-5 | Test Summary Report |
+| WIA-SOP-71 | Wales Informatics Assurance Group (WIAG) Process |
+| N/A | [Writing checklist (sharepoint.com)](https://nhswales365.sharepoint.com/sites/DHC_ENG/SitePages/Writing-guidelines.aspx) |
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions.
+
+    If a hyperlink is missing, search for the document in the Document Management System.
+
+[^1] And later versions.

--- a/doc/test-summary-report/layout-and-formatting.md
+++ b/doc/test-summary-report/layout-and-formatting.md
@@ -1,0 +1,11 @@
+# Layout and formatting
+
+For brevity, formatting rules such as, font, line spacing & paragraph
+settings, headers and footers are omitted. You **SHOULD** keep to those
+used in the blank template.
+
+if you need to insert document references in the footer you **MAY**
+remove the footer image to ensure the text is clearly visible.
+
+You **SHOULD** strive to ensure the report displays well in Microsoft
+Word on desktop and online.

--- a/doc/test-summary-report/relevant-documents.md
+++ b/doc/test-summary-report/relevant-documents.md
@@ -1,0 +1,9 @@
+# Relevant documents
+
+You **SHOULD** include links to the Test Strategy, Test Plan and
+Solutions Architecture Design document. And reference the Assurance
+Quality Plan and Safety Case and Readiness Report where they exist. You
+**SHOULD NOT** embed documents.
+
+!!! tip "Practical tips"
+    Use external links cautiously as they may become outdated or broken over time.

--- a/doc/test-summary-report/reviews-and-approvals.md
+++ b/doc/test-summary-report/reviews-and-approvals.md
@@ -1,0 +1,5 @@
+# Reviews and approvals
+
+Recording reviewers and approvers using electronic signatures is
+**RECOMMENDED**, but you **MAY** instead record the name and date of the
+reviewer and approver. See also [Roles & Responsibilities](introduction.md#roles-responsibilities).

--- a/doc/test-summary-report/summary-of-testing.md
+++ b/doc/test-summary-report/summary-of-testing.md
@@ -1,0 +1,18 @@
+# Summary of testing
+
+The Testing summary **MUST** contain the following headings: -
+
+| **RECOMMENDATION:** | Your recommendation based on the findings. Written in bold font. |
+| --- | --- |
+| **Observations and Variances:** | Any noteworthy findings, deviations from expected results, and any observed variations. It is essential to capture anything left untested together with an associated reason, for example, limitations on availability of test devices. |
+| **Background:** | A brief overview of the application, the features and components under test and any relevant context. |
+| **Approach:** | The testing strategy employed, including automation, manual testing, or any specific methodologies. |
+| **Entry Criteria:** | Entry criteria are the specific conditions that must be met before testing can begin. Including these criteria is useful, especially if you need to explain any exceptions when proceeding. |
+| **Test Phase:** | Specify the phase of testing covered in this report. Be guided by 'Test Phases' in the 'Test Framework' (pages 26 - 30). |
+| **Test Types:** | Enumerate the distinct types of testing conducted. Be guided by 'Appendix 4' of the 'Test Framework' (pages 52 - 56) but you **MAY** include others. |
+| **Test Environment:** | The technical setup and configurations used for testing. |
+| **Dates:** | Specify the duration of the testing period and key milestones. |
+| **Test Tools:** | The tools used for testing purposes. |
+| **In-Scope:** | The features, components and interfaces considered during testing. |
+| **Out-of-scope:** | What was explicitly excluded from the testing scope. |
+| **Exit criteria:** | The predetermined conditions that must be met for testing to be considered complete and successful. |

--- a/doc/test-summary-report/table-of-contents.md
+++ b/doc/test-summary-report/table-of-contents.md
@@ -1,0 +1,3 @@
+# Table of contents
+
+You **MUST** include a Table of Contents.

--- a/doc/test-summary-report/test-metrics.md
+++ b/doc/test-summary-report/test-metrics.md
@@ -1,0 +1,8 @@
+# Test metrics
+
+The Testing summary **SHOULD** contain the following headings :-
+
+| **Execution Metrics:** | A snapshot of the test script execution, including pass, fail, completion status, and any deferred or not applicable scripts. |
+| --- | --- |
+| **Defect Metrics:** | Summarises the initial defects, total raised, closed, and currently open defects, categorised by severity. |
+| **Open Defects:** | Describes the currently open defects, with their Azure DevOps ID and severity. |

--- a/doc/test-summary-report/version-control.md
+++ b/doc/test-summary-report/version-control.md
@@ -1,0 +1,8 @@
+# Version control
+
+You **SHOULD** include the present version and any predecessor versions
+with brief accompanying notes describing changes and reasons for the
+change.
+
+Revision History statuses **SHOULD** be limited to *Draft, Draft-Update*
+or *Issued.*

--- a/doc/test-summary-report/when-to-create-a-test-summary-report.md
+++ b/doc/test-summary-report/when-to-create-a-test-summary-report.md
@@ -1,0 +1,9 @@
+# When to create a test summary report
+
+You **SHOULD** draft a report at the end of a project, but you **MAY**
+do so for the end of each testing cycle.  Typically, it will be written
+for any new service, major change or new developments in existing
+services, releases, procurements, proof of concepts and innovation
+products[^1].
+
+[^1]: WIA-SOP-71 Wales Informatics Assurance GROUP (WIAG) Process, section 2 Scope.

--- a/doc/testing-lost-updates/concurrency-controls.md
+++ b/doc/testing-lost-updates/concurrency-controls.md
@@ -1,0 +1,10 @@
+# Concurrency controls
+
+The table shown below describes common approaches to concurrency
+control.
+
+|  | **Pessimistic or Optimistic?** | **Coarse grained or Fine grained?** |
+| --- | --- | --- |
+| **Locking** | *Pessimistic* - locks on View/Edit. *Optimistic* - Blocks on save - not really a lock. | *Coarse grained* -- locks the entire record. *Fine grained* -- locks the active field(s). |
+| **Validation checks** | Users may unknowingly overwrite changes with their own, but validity is assured. |  |
+| **No control** | The specification limits access to a single user per record at a time. |  |

--- a/doc/testing-lost-updates/example-test-scripts.md
+++ b/doc/testing-lost-updates/example-test-scripts.md
@@ -1,0 +1,15 @@
+# Example test scripts
+
+| **ID** | **TEST CASE** |
+| --- | --- |
+| [9045](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/9045) | Lock 01 Test Requesting |
+| [9046](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/9046) | Lock 02 - Medicines |
+| [9047](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/9047) | Lock 03 Editing DAL |
+| [9667](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/9667) | Lock 04 - Referrals |
+| [9049](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/9049) | Lock 05 - Accessing and editing the orbeon forms from external applications |
+| [10486](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/10486) | Lock 06 - User having multiple sessions of WCP using different machines |
+| [16647](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/16647) | Lock 07 - Multiple Users Accessing Various Patient Records Simultaneously |
+| [35763](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems?id=35763) | Lock 08 - User tries to open multiple WCP sessions on same machine |
+| [64131](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/64131) | Lock 09 - Radiology Test Requesting |
+| [78270](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/78270) | GENERIC - Neonatal Details Screen - Record locking test case |
+| [83414](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems?id=83414) | DM+12c: Child Consents Screen - locking test |

--- a/doc/testing-lost-updates/follow-a-risk-based-approach.md
+++ b/doc/testing-lost-updates/follow-a-risk-based-approach.md
@@ -1,0 +1,20 @@
+# Follow a risk based approach
+
+When preparing your tests, identify when and where failure is most
+likely to occur and where impact will be most severe. The system under
+test will have some potential for concurrency conflicts it *must*
+manage. But what else should you consider?
+
+While **not** an exhaustive list, nor a replacement for
+your own expertise, this table sets out questions and tasks to consider.
+
+| **Considerations** | **Tasks** |
+| --- | --- |
+| **Is the code multi-threaded?** Most applications rely on multi-threading even before the developer starts coding. But code that creates its own threads, poses a particular risk. Especially when writing an automated process that creates high numbers of transactions. | Ask the developers to walk you through their stress tests |
+| **How many *users* and *concurrent users* do you expect?** The potential for concurrency conflicts grows with the number of *users*, particularly *concurrent* *users*. | Ask Business Analysts to walk you through the non-functional requirements. Make sure to record acceptance criteria in user stories, requirements specifications or the team's definition of done. |
+| **How complicated is the approach?** We call the design to handle concurrency conflicts *concurrency control*. While there are common ways to approach this, some are more difficult to reason about and put in place. | Ask the developer or architect to walk you through the solution architecture. |
+| **How mature is the implementation?** You may have already implemented concurrency control. If so, there may be less risk of it failing for a new feature.[^1] | Ask the developers to walk you through their tests. Check the team's *definition of done*. |
+| **How much support does the development framework provide?** Some frameworks provide much of the heavy lifting to deal with concurrency conflicts. Oracle Forms, although now deprecated, is a good example. Entity Framework's optimistic locking another. These frameworks are tried and tested and can reduce the amount of testing required. | Ask developers how much bespoke code they have written and which framework they use. |
+
+[^1]: For example, you may follow the *implicit lock pattern,* making it
+    easier to add locks to new features.

--- a/doc/testing-lost-updates/further-reading.md
+++ b/doc/testing-lost-updates/further-reading.md
@@ -1,0 +1,5 @@
+# Further reading
+
+1. Defensive Database Programming with SQL Server, Chapter 10: **Alex Kuznetsov, Simple Talk Publishing (2010)**
+
+2. Patterns of Enterprise Application Architecture, Chapter 5: **Martin Fowler**, **Addison-Wesley (2002)**

--- a/doc/testing-lost-updates/how-do-you-test-for-lost-updates.md
+++ b/doc/testing-lost-updates/how-do-you-test-for-lost-updates.md
@@ -1,0 +1,25 @@
+# How do you test for lost updates
+
+Rick and Liz call for a review into the application's safety. This leads
+to a software change to prevent lost updates. How would you test it?
+
+In a web app, you might mimic each user by opening a new browser tab.
+Using Google Chrome's incognito mode for example. Or you might run the
+application on two machines. How robust would these tests be?
+
+And what if the *users* were software threads rather than people.
+Triggered to send almost simultaneous database updates? You would need a
+different test.
+
+Use this guide to test such scenarios. It is a response to
+recommendations found in a 2018 report.
+
+!!! tip "Practical tips"
+    **Welsh Admin Portal -- Root Cause Analysis**
+
+    An investigation into why some patients were not assigned to waiting lists in the Welsh Patient Administration System concluded that;
+
+    'The design and implementation did not account for (or handle) the potential for concurrency conflicts...Routine testing did not identify the issue'
+
+!!! info "Further reading and information"
+    RPT-231026APRIL18 -WAP Redirect RCA.docx

--- a/doc/testing-lost-updates/introduction.md
+++ b/doc/testing-lost-updates/introduction.md
@@ -1,0 +1,71 @@
+# Introduction
+
+## Purpose
+
+To help you test for lost updates and other database concurrency bugs.
+You will learn -
+
+- How collaboration improves testing and why developers should also
+    write test scripts.
+
+- How to follow our Test Framework and apply a risk-based approach.
+
+- Common patterns, architects and developers use to solve concurrency
+    conflicts.
+
+- The types of tests you will need and examples of authentic test
+    scripts.
+
+## Scope
+
+### In-scope
+
+- This guide helps you to test software and follow our Test Framework.
+
+### Out-of-scope
+
+- Post-deployment surveillance tests are not included in scope.
+
+## Roles & responsibilities
+
+We write this for Test Analysts. But everyone has a part to play :-
+
+- Business analysts determine the need for concurrency in the
+    requirements.
+
+- Architects and developers build concurrency control into the
+    designs.
+
+- Developers and testers verify these designs beyond the user
+    interface.
+
+- Support run surveillance scripts to continue testing after
+    deployment.
+
+- Everyone takes part in sprint ceremonies. Because these interactions
+    refine your approach, ensuring it's fit for purpose.
+
+Only by doing this, will you have confidence to test for lost updates
+and concurrency bugs.
+
+## References
+
+1. [Software development handbook](../software-development-handbook/introduction.md)
+
+2. Test framework
+
+## How this guide is organised
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions.
+
+    If a hyperlink is missing, search for the document in the Document Management System.

--- a/doc/testing-lost-updates/locking.md
+++ b/doc/testing-lost-updates/locking.md
@@ -1,0 +1,47 @@
+# Locking
+
+Locking prevents concurrency conflict, eliminating the potential for
+lost updates. Locking designs take into consideration the chance of a
+conflict occurring and the scope to which we should apply the lock.
+
+## Pessimistic or optimistic
+
+***Pessimistic locks*** expect conflict, so they block access to one
+user at a time. Whether you apply the lock on *View* or *Edit* depends
+on the requirements. But other users must wait for the lock to release.
+
+Applying *pessimistic* locking in our example means Liz must wait for
+Rik to save changes before she can edit.
+
+By contrast, ***Optimistic locking*** does not block access because
+it does not expect a conflict to occur. But it does stop a user from
+saving changes if the data has changed.
+
+Applying this to our example, Rik is forced to reload the data (with
+Liz's changes) and start again.
+
+## Coarse or fine grained
+
+Based on requirements, locks may apply to the entire patient record -
+spanning many data entry forms. Or they may apply to a specific field or
+fields[^1] - on an active part of a form for example.
+
+Any locking strategy must also ensure data integrity. A locking strategy
+that allows users to assign an invalid combination of GP and GP Practice
+is still wrong!
+
+## No locking, but validation checks
+
+Rather than locking, applications may check updates are consistent with
+existing data. Serializing database access and updating only the fields
+that change is one approach.
+
+## No concurrency controls
+
+Typically the system under test will need to manage concurrency
+conflicts. But it may not always be necessary. Make sure to find out!
+
+!!! tip "Practical tips"
+    Even if a requirements specification omits concurrency control it does not necessarily mean it is not needed. Encourage your business analysts, architects and developers to record it in their documentation!
+
+[^1]: Although locking at field level is unlikely to be practical for Pessimistic locking.

--- a/doc/testing-lost-updates/whats-a-lost-update.md
+++ b/doc/testing-lost-updates/whats-a-lost-update.md
@@ -1,0 +1,25 @@
+# What's a lost update
+
+A lost update can occur when two or more *users* change a shared piece
+of data at the same time. A *user* is a person or automated process.
+Consider this hypothetical example:
+
+1. Dr Rick Dagless loads patient X's data onto a web form, to record
+    their allergy to penicillin.
+
+2. Meanwhile, Dr Liz Asher also loads patient X's data. She clicks a
+    checkbox to record that the patient lives alone and immediately
+    saves her changes.
+
+3. Rick saves his changes with *lives alone* unchecked. In doing so he
+    unknowingly overwrites Liz's change.
+
+We call the action of loading and saving changes to data a
+*transaction*. When the result of one transaction is dependent on the
+sequence or timing of another, it's called a *concurrency conflict* or
+*race condition*.
+
+In our example, the result is the loss of a lasting record that the
+patient lives alone. And this is a patient safety concern - imagine if
+the checkbox indicated the need to refer the patient for urgent
+treatment!

--- a/doc/testing-lost-updates/write-and-execute-tests.md
+++ b/doc/testing-lost-updates/write-and-execute-tests.md
@@ -1,0 +1,12 @@
+# Write and execute tests
+
+Use the table below, together with your own expertise, to determine the
+types of tests you need.
+
+| **TEST TYPE** | **TYPE OF WORK PERFORMED** |
+| --- | --- |
+| Functional GUI testing | Often manual tests. For example, to check locking behaviour or determine what happens when a user logs in many times. The next page lists some authentic examples. |
+| Functional Data testing | Using tools like SQL Server Management Studio, to check for accuracy as we load and save data in the GUI. For example, some tests on the next page check a table called *FunctionLock* to verify the lock requested in the user interface exists in the database. Combined with functional GUI testing, functional data testing is highly effective. But it has limitations. Consider the first 10 steps of [9045 Test Requesting](https://dev.azure.com/NHS-Wales-Digital/WCP/_workitems/edit/9045) What happens if both *User A* and *User B* choose the same patient at the same time? Can you be sure who gets the lock? Both? How do you guarantee the database commands execute concurrently to make sure both users are not allowed to lock the same patient record? For fine grained control you execute your functional data tests with code walk-throughs, debugging and unit tests. |
+| Code walk-throughs and debugging | Ask developers to walk you through their tests and include these in your strategy and plans. |
+| Non-functional stress tests | The techniques above go a long way to providing confidence. But also consider using stress tests, particularly when writing an automated software process. They need not be too involved. Developers can write simple tests using T-SQL -- see [FURTHER READING](further-reading.md). Again, include them in your strategy and plans. |
+| Monitoring and surveillance | Post deployment monitoring and surveillance is beyond the scope of this guide. But teams should continue to test for lost updates and deadlocks after deployment. |

--- a/doc/using-source-control/adopt-trunk-based-development-and-continuous-integration.md
+++ b/doc/using-source-control/adopt-trunk-based-development-and-continuous-integration.md
@@ -1,0 +1,25 @@
+# Adopt trunk-based development and continuous integration
+
+Trunk-Based Development simplifies source control by deploying directly
+from the trunk branch (e.g., main or master). You **SHOULD** adopt this
+approach where feasible, as it minimises the complexity of managing
+long-lived branches.
+
+**RECOMMENDATIONS**:
+
+- Write a comprehensive suite of automated tests to keep branches
+    deployable.
+
+- Aim for continuous integration and frequent deployments from the
+    trunk.
+
+**When to Consider Alternatives**:
+
+If your project requires extensive experimentation or long-term feature
+development, ensure robust practices for merging changes from feature
+branches.
+
+!!! info "Further reading and information"
+    [It's Not Continuous Delivery If You Can't Deploy Right Now - YouTube](https://www.youtube.com/watch?v=po712VIZZ7M)
+
+    [Git patterns and anti-patterns for successful developers - YouTube](https://www.youtube.com/watch?v=t_4lLR6F_yk)

--- a/doc/using-source-control/always-deploy-from-source-control.md
+++ b/doc/using-source-control/always-deploy-from-source-control.md
@@ -1,0 +1,14 @@
+# Always deploy from source control
+
+You **MUST** ensure all deployments originate from source control to
+maintain traceability. Use Git tags or branches to track and manage
+deployments.
+
+You **MUST NOT** manually copy changes between environments.
+
+!!! tip "Practical tips"
+    **WPRS -- Prioritisation incident**
+
+    In 2016, a clinical incident review (ref. 58337) found a missing table alias in a SQL Select statement as the root cause of certain referrals which had been missed for assessment.
+
+    It found that had the code been deployed from source control, the risk of not spotting the error before going live would have reduced.

--- a/doc/using-source-control/commit-changes-early-and-often.md
+++ b/doc/using-source-control/commit-changes-early-and-often.md
@@ -1,0 +1,22 @@
+# Commit changes early and often
+
+Committing code early and often provides several benefits:
+
+- It reduces the risk of losing code, e.g., due to local disk failure.
+
+- It encourages building smaller, modular components, simplifying
+    rollback.
+
+- It makes integrating changes into the main or master branch easier.
+
+You **MUST** commit changes to your main codebase as soon as possible,
+regardless of whether you are using [trunk-based
+development](adopt-trunk-based-development-and-continuous-integration.md)
+or [feature branches](follow-a-branching-strategy.md).
+
+You **SHOULD** commit related changes together and keep commits as small
+as possible. Smaller commits make rollback easier and minimise
+disruptions.
+
+You **SHOULD NOT** commit large batches of unrelated work. It
+complicates code reviews and rollbacks.

--- a/doc/using-source-control/essential-good-practice-checklist.md
+++ b/doc/using-source-control/essential-good-practice-checklist.md
@@ -1,0 +1,12 @@
+# Essential good practice checklist
+
+| **No.** | **Checklist Item** |  | **Guide or Standard** | **Exceptions** |
+| --- | --- | --- | --- | --- |
+| 1 | You store program code in our source control systems. | ☐ | [Use our source control systems](use-our-source-control-systems.md) |  |
+| 2 | You have planned a clear repo structure. | ☐ | [Establish a clear repo structure](establish-a-clear-repo-structure.md) |  |
+| 3 | You follow a documented, well-understood branching strategy. | ☐ | [Follow a branching strategy](follow-a-branching-strategy.md) |  |
+| 4 | You have a versioning strategy that clearly indicates breaking changes in updated versions. | ☐ | [Implement a versioning strategy](implement-a-versioning-strategy.md) |  |
+| 5 | Your write clear commit messages following the conventional commits specification. | ☐ | [Write clear commit messages](write-clear-commit-messages.md) |  |
+| 6 | You use an automated build and deployment pipeline that builds all components and includes validation checks, such as unit tests, linting, and schema validation. | ☐ | [Always deploy from source control](always-deploy-from-source-control.md) |  |
+| 7 | You have an automated build and deployment pipeline (or re-runnable and source-controlled scripts) for relevant environments, such as - *System Integration Testing* (sometimes called *Test* or *QA*) *User Acceptance Testing* (if applicable) *Production* | ☐ | [Always deploy from source control](always-deploy-from-source-control.md) |  |
+| 8 | You manage deployments to each environment using Git's branch and tag commands. | ☐ | [Always deploy from source control](always-deploy-from-source-control.md) |  |

--- a/doc/using-source-control/establish-a-clear-repo-structure.md
+++ b/doc/using-source-control/establish-a-clear-repo-structure.md
@@ -1,0 +1,62 @@
+# Establish a clear repo structure
+
+## Before creating your repo
+
+You **MUST** have a clear plan for how to organise your repos. You have
+three main options:
+
+| **REPO TYPE** | **Description** |
+| --- | --- |
+| **MONOREPO** | A single repo for all our organisation's source code. We do not use this approach and it is **NOT RECOMMENDED** to have all teams share one Azure DevOps project. |
+| **SINGLE REPO** | Each team stores its code in the same repo. This is the **RECOMMENDED** approach for most cases but requires automation to manage the process effectively. |
+| **MULTIREPO** | Each application has its own repo. This may be necessary if you have specific constraints that make this approach better for your team. |
+
+## Managing multiple applications in the same repo
+
+Your repos **MUST NOT** become a confusing mess. To keep them organised
+you **MUST**:
+
+- Deploy applications only when code changes are made to that specific
+    application.
+
+- Restrict access to distinct parts of your codebase when needed.
+
+For example, the Single Record Product team might face these scenarios:
+
+| **PROBLEM** | **SOLUTION** |
+| --- | --- |
+| The Welsh Clinical Portal mobile and web apps share common libraries in the same repo, but changes to one app should not trigger deployments of the other. | Set up build pipelines to trigger only when code changes occur in specific directories. |
+| Contractors working on the Welsh Nursing Care Record form should not be able to modify the Welsh Clinical Portal apps. | Use branch policies or security settings to limit access. |
+
+## Choosing between single and multirepos?
+
+Using a *Single Repo* is **RECOMMENDED** for apps that share a release
+cadence, like a desktop app and its back-end API. This approach is also
+good for components that are deployed together.
+
+If you choose a single repo, you **MUST** automate builds and
+deployments and follow the folder structure outlined in *How to Organise
+Your Software Solution.*
+
+If your apps are each tied to their own Visual Studio .sln file,
+*Multirepo* may be a better fit.
+
+!!! tip "Practical tips"
+    Even when using a single repo for common libraries, you **SHOULD** use package management to publish binaries.
+
+    Repos and branches serve a different purpose. See the Azure DevOps handbook for details.
+
+!!! info "Further reading and information"
+    [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [Structure your Git Repo - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/modules/structure-your-git-repo/)
+
+    [Working with a Monorepo - CSE Developer Blog (microsoft.com)](https://devblogs.microsoft.com/cse/2021/11/23/working-with-a-monorepo/)
+
+    [Monorepos in Git \| Atlassian Git Tutorial](https://www.atlassian.com/git/tutorials/monorepos)
+
+    [Misconceptions about Monorepos: Monorepo != Monolith](https://blog.nrwl.io/misconceptions-about-monorepos-monorepo-monolith-df1250d4b03c)
+
+    [The Big Ball of Mud and Other Architectural Disasters (codinghorror.com)](https://blog.codinghorror.com/the-big-ball-of-mud-and-other-architectural-disasters/)

--- a/doc/using-source-control/exceptions.md
+++ b/doc/using-source-control/exceptions.md
@@ -1,0 +1,4 @@
+# Exceptions
+
+While there may be reasons to deviate from this guide, exceptions should
+be rare and carefully considered.

--- a/doc/using-source-control/follow-a-branching-strategy.md
+++ b/doc/using-source-control/follow-a-branching-strategy.md
@@ -1,0 +1,27 @@
+# Follow a branching strategy
+
+You **MUST** implement a branching strategy that fits your team's
+needs. A clear strategy helps minimise risks like introducing bugs or
+conflicts. While [Trunk-Based Development](adopt-trunk-based-development-and-continuous-integration.md)
+is **RECOMMENDED**, select the approach best suited to your project.
+
+Your branching strategy **MUST**:
+
+- Define a consistent branch naming convention. See the Azure DevOps
+    handbook for details.
+
+- Be documented in the project's README.md and CONTRIBUTING.md file or team wiki.
+
+!!! tip "Practical tips"
+    Use tools like Jakob Ehn's *GitFlow for Visual Studio* if they simplify branch management for your team.
+
+!!! info "Further reading and information"
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [Patterns for Managing Source Code Branches (martinfowler.com)](https://martinfowler.com/articles/branching-patterns.html)
+
+    [A successful Git branching model » nvie.com](https://nvie.com/posts/a-successful-git-branching-model/)
+
+    [Introducing GitFlow for Visual Studio - blog.ehn.nu](https://blog.ehn.nu/2015/02/introducing-gitflow-for-visual-studio/)
+
+    [GitFlow \| Visual Studio, Visual Studio Marketplace](https://marketplace.visualstudio.com/search?term=gitflow&target=VS&category=All%20categories&vsVersion=&sortBy=Relevance)

--- a/doc/using-source-control/implement-a-versioning-strategy.md
+++ b/doc/using-source-control/implement-a-versioning-strategy.md
@@ -1,0 +1,55 @@
+# Implement a versioning strategy
+
+A versioning strategy **MUST** define how you assign, increment, and
+publish version numbers. It **SHOULD** integrate with your branching
+strategy to streamline builds and deployments.
+
+## Use semantic versioning
+
+The Semantic Versioning (SemVer 2.0.0) specification is **RECOMMENDED**
+and **MUST** be used for public APIs and NuGet packages. SemVer makes it
+easier for consumers to understand breaking, additive, or patch-level
+changes.
+
+## Automate version numbering
+
+Use tools like **Nerdbank.GitVersioning** to generate SemVer compliant
+versions during builds.
+
+!!! tip "Practical tips"
+    For .NET projects, NuGet 4.3.0+ supports SemVer 2.0.0.
+
+    For APIs, include version numbers only if updates are expected; omit them for static APIs.
+
+    For C# projects, use the obsolete attribute to warn about upcoming deprecations.
+
+    Don't confuse semantic versioning, which reflects technical compatibility, with product versions which often align with release schedules.
+
+!!! info "Further reading and information"
+    [RESTful API Design and Build Standards](../restful-api-standards/introduction.md)
+
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+    [Semantic Versioning 2.0.0 \| Semantic Versioning](https://semver.org/)
+
+    [NuGet Package Version Reference \| Microsoft Learn](https://learn.microsoft.com/en-gb/nuget/concepts/package-versioning?tabs=semver20sort)
+
+    [Versioning and .NET libraries - .NET \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/library-guidance/versioning)
+
+    [API Versioning Options · dotnet/aspnet-api-versioning Wiki](https://github.com/dotnet/aspnet-api-versioning/wiki/API-Versioning-Options)
+
+    [API versioning misconceptions: When you need it and when you don't \| Google Cloud Blog](https://cloud.google.com/blog/products/api-management/common-misconceptions-about-api-versioning)
+
+    [apigee-web-api- design-the-missing-link-ebook.pdf](https://cloud.google.com/files/apigee/apigee-web-api-design-the-missing-link-ebook.pdf) (page 56)
+
+    [Breaking changes and .NET libraries - .NET \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/standard/library-guidance/breaking-changes)
+
+    [Attributes interpreted by the compiler: Miscellaneous - C# reference \| Microsoft Learn](https://learn.microsoft.com/en-gb/dotnet/csharp/language-reference/attributes/general#obsolete-attribute)
+
+    <https://github.com/dotnet/Nerdbank.GitVersioning>
+
+    [Versioning limitations in .NET \| Jon Skeet's coding blog](https://codeblog.jonskeet.uk/2019/06/30/versioning-limitations-in-net/)
+
+    [Semantic Versioning and Patch 2.1.2 \| Alan Kent's Blog](https://alankent.me/2016/09/20/semantic-versioning-and-patch-2-1-2/)
+
+    [API Versioning Explained \| Lightboard Series](https://www.youtube.com/watch?v=_WWr_eFRDeM)

--- a/doc/using-source-control/introduction.md
+++ b/doc/using-source-control/introduction.md
@@ -1,0 +1,72 @@
+# Introduction
+
+## Purpose
+
+A guide to working with source control. Following it helps you meet our
+requirements for developing software described in our Software
+development handbook.
+
+!!! info "Further reading and information"
+    [Software development handbook](../software-development-handbook/introduction.md)
+
+## Scope
+
+### In-scope
+
+- Good practices for using source control and conducting code reviews.
+
+- Strategies for organising Git repositories.
+
+- Strategies for branching and merging.
+
+- [Good practice checklist](../restful-api-standards/essential-good-practice-checklist.md).
+
+### Out-of-scope
+
+- In depth guidance for creating and configuring Git repos. See our
+    Azure DevOps handbook for details.
+
+- This guide is for Azure DevOps users, specifically those using Azure
+    Repos. GitHub users may find it helpful, but it is not tailored for
+    them.
+
+!!! tip "Practical tips"
+    Some links in this handbook now point to GitHub resources - as Microsoft increasingly promotes GitHub in marketing and training.
+
+## References
+
+1. [Software development handbook](../software-development-handbook/introduction.md)
+
+2. [RESTful API Design and Build Standards](../restful-api-standards/introduction.md)
+
+3. [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+
+4. [Azure DevOps handbook](../azure-devops-handbook/introduction.md)
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**,
+**SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**,
+**RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+!!! tip "Practical tips"
+    Practical tips
+
+!!! example "Examples of good practice"
+    Examples of good practice...
+
+!!! warning "Practices to avoid"
+    ...and practices to avoid
+
+!!! info "Further reading and information"
+    Links to further guides, information and work instructions. If a hyperlink is missing, search for the document in our Document Management System.
+
+## The need for guidance
+
+Source control, or version control, helps you stay organised by tracking
+changes to your files as you fix bugs or add features. It lets you
+easily revert to earlier versions when needed,
+
+Using our source control systems helps you comply with company Disaster
+Recovery policies.

--- a/doc/using-source-control/keep-your-repo-organised.md
+++ b/doc/using-source-control/keep-your-repo-organised.md
@@ -1,0 +1,14 @@
+# Keep your repo organised
+
+You **SHOULD** maintain clean, organised repositories by:
+
+- Removing stale or unused projects.
+
+- Reviewing & revoking unnecessary permissions with Windows Groups for
+    access control.
+
+Where possible, projects **SHOULD** be open for others to read and
+contribute.
+
+!!! info "Further reading and information"
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)

--- a/doc/using-source-control/review-your-code.md
+++ b/doc/using-source-control/review-your-code.md
@@ -1,0 +1,28 @@
+# Review your code
+
+Code reviews help improve code quality, increase team knowledge, and
+develop coding skills, particularly for new team members. While it is
+not always possible to have your code reviewed before committing to the
+main branch, it is **RECOMMENDED**.
+
+When implementing code reviews, you **MUST** ensure the following are
+clearly documented in the project's README.md and CONTRIBUTING.md file.
+or team wiki:
+
+- The purpose of code reviews and the coding standards your code must
+    adhere to.
+
+- The minimum number of reviewers required to approve a commit. Two
+    reviewers are **RECOMMENDED**.
+
+Additional **RECOMMENDATIONS**:
+
+- Consider using *pair programming* for real-time code review and
+    feedback.
+
+- Use *Pull Requests* to facilitate and track your code reviews.
+
+!!! tip "Practical tips"
+    **ISO 9001:2015 Audit Recommendation**
+
+    An external ISO 9001:2015 audit in 2020 recommended that teams define a minimum number of code reviewers rather than inviting the entire team to review a commit.

--- a/doc/using-source-control/select-and-configure-git-clients.md
+++ b/doc/using-source-control/select-and-configure-git-clients.md
@@ -1,0 +1,15 @@
+# Select and configure Git clients
+
+There are many Git clients available. However, Visual Studio is
+**RECOMMENDED**, which includes a built-in Git client. Regardless of the
+Git client, you **MUST**:
+
+- Ensure it is properly licenced.
+
+- Regularly apply the latest security patches.
+
+- Verify that your Git settings, both local and remote, reflect your
+    NHS Wales identity.
+
+!!! info "Further reading and information"
+    [Git - GUI clients](https://git-scm.com/)

--- a/doc/using-source-control/use-git.md
+++ b/doc/using-source-control/use-git.md
@@ -1,0 +1,23 @@
+# Use Git
+
+Visual Studio and Azure DevOps offer two source control tools through
+Azure Repos: Team Foundation Version Control and Git (the default). You
+**SHOULD** use Git. While it has a steeper learning curve, it is better
+suited to help you follow these standards.
+
+!!! info "Further reading and information"
+    [Manage source control - Training \| Microsoft Learn](https://learn.microsoft.com/en-gb/training/paths/az-400-manage-source-control/)
+
+    [Git Book](https://git-scm.com/book/en/v2)
+
+    [Get started with Git and Visual Studio - Azure Repos \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/repos/git/gitquickstart?tabs=visual-studio-2022&view=azure-devops)
+
+    [Azure Repos Git Documentation \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/repos/git/?view=azure-devops)
+
+    [About Git in Visual Studio \| Microsoft Learn](https://learn.microsoft.com/en-gb/visualstudio/version-control/git-with-visual-studio?view=vs-2022)
+
+    [Git and TFVC version control - Azure Repos \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/repos/tfvc/comparison-git-tfvc?view=azure-devops)
+
+    [Map TFVC actions to Git - Azure Repos \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/repos/git/mapping-my-tfvc-actions-to-git?tabs=command-line&view=azure-devops)
+
+    [Change the Work Items page experience - Azure Boards \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/boards/work-items/set-work-item-experience-vs?view=azure-devops&viewFallbackFrom=azure-devops)

--- a/doc/using-source-control/use-our-source-control-systems.md
+++ b/doc/using-source-control/use-our-source-control-systems.md
@@ -1,0 +1,8 @@
+# Use our source control systems
+
+Any code not in source control is considered outside your project. You
+**MUST** commit all code to our source control systems. You can find
+more details from our Azure DevOps handbook.
+
+!!! info "Further reading and information"
+    [Azure DevOps handbook](../azure-devops-handbook/introduction.md)

--- a/doc/using-source-control/what-to-include-in-source-control.md
+++ b/doc/using-source-control/what-to-include-in-source-control.md
@@ -1,0 +1,37 @@
+# What to include in source control
+
+You **MUST** include:
+
+- Everything needed to build your project, including the database.
+
+- A README.md and CONTRIBUTING.md file. Other documentation **MAY** be
+    kept outside source control.
+
+You **MUST NOT** include:
+
+- Sensitive information, such as API keys, passwords, or server names.
+    Instead, use environment variables or key stores.
+
+- Personal Identifiable Information (PII).
+
+You **SHOULD** exclude:
+
+- Compilation output and user settings files. Use a .gitignore file
+    (e.g., for Visual Studio) to manage exclusions.
+
+Additional **RECOMMENDATIONS**:
+
+- Use Redgate Source Control to manage your database.
+
+- Use package management to avoid storing dependencies in source
+    control.
+
+!!! tip "Practical tips"
+    **Disaster Recovery**
+
+    In 2017, a disaster recovery test revealed weaknesses in our source control system, risking longer recovery times and data loss. These issues **HAVE** since been resolved.
+
+!!! info "Further reading and information"
+    [How to Organise Your Software Solution](../organising-your-solution/introduction.md)
+
+    [gitignore/VisualStudio.gitignore at main · github/gitignore](https://github.com/github/gitignore/blob/main/VisualStudio.gitignore)

--- a/doc/using-source-control/write-clear-commit-messages.md
+++ b/doc/using-source-control/write-clear-commit-messages.md
@@ -1,0 +1,120 @@
+# Write clear commit messages
+
+Commit messages are essential for understanding the history, context,
+and purpose of code changes. Following these standards will:
+
+- Improve collaboration and communication across teams.
+
+- Make it easier to debug, trace changes and manage the codebase
+    effectively.
+
+- Ensure consistency and professionalism in your projects.
+
+You **MUST** write a commit message for every change.
+
+Commit messages **MUST** be clear, concise, and follow a consistent
+format.
+
+You **SHOULD:**
+
+- Use the Conventional Commits specification to structure your
+    messages.
+
+- Link commits to work items, bugs, or tasks using identifiers.
+
+!!! tip "Practical tips"
+    In Visual Studio, include the work item ID, e.g., #123 , in your commit message. Visual Studio will automatically link the commit to the corresponding work item.
+
+Additional **RECOMMENDATIONS**:
+
+- Consider tools like VsCommitizen or commitlint to help enforce
+    standards.
+
+- Use branch policies to ensure commit messages comply with
+    requirements.
+
+- Use "because" in your message to clarify the reasoning behind
+    changes.
+
+!!! info "Further reading and information"
+    [Conventional Commits](https://www.conventionalcommits.org)
+
+    [VsCommitizen - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=mrluje.vs-commitizen&ssr=false#qna)
+
+## Commit message standard
+
+Each commit message **MUST** follow this template:
+
+!!! example "Examples of good practice"
+    *<type**\>\[optional scope\]: description*
+
+    *\[optional body\]*
+
+    *\[optional footers\]*
+
+*<type\>:* describes the purpose of the commit. You **MUST** append a !
+to *<type\>* if the commit introduces a breaking change (e.g. `feat`!).
+
+| **TYPE** | **DESCRIPTION** |
+| --- | --- |
+| `feat`: | A new feature. |
+| `fix`: | A bug fix. |
+| `build`: | Changes to the build system or dependencies. |
+| `chore`: | Maintenance tasks that do not affect application functionality. |
+| `ci`: | Changes to CI/CD pipelines or configuration. |
+| `docs`: | Documentation updates. |
+| `style`: | Code formatting changes (e.g., indentation, spacing) without functional impact. |
+| `refactor`: | Code changes that improve structure & clarity without changing behaviour. |
+| `perf`: | Performance improvements. |
+| `test`: | Adding or modifying tests |
+
+The *<summary\>* **MUST**:
+
+- Be 50 characters or fewer.
+
+- Use the imperative mood (e.g. "Add login validation").
+
+The *<body\>* **SHOULD**:
+
+- Provide additional context (e.g. **why** a change was made).
+
+- Be wrapped at 72 characters per line for readability.
+
+Additional **RECOMMENDATIONS**:
+
+- Avoid ending with punctuation.
+
+!!! example "Examples of good practice"
+    *feat: Add support for user authentication*
+
+    *Introduced OAuth-based login for secure access. Closes Task#1234*
+
+!!! example "Examples of good practice"
+    *fix: Resolve API timeout issue on large datasets*
+
+    *Adjusted query execution to improve performance. Resolves Bug#5678*
+
+!!! example "Examples of good practice"  
+    *docs: Update README with deployment instructions*
+
+    *Added steps for configuring environment variables and services*
+
+!!! warning "Practices to avoid"
+    *Changeset 12345*
+
+    *The best version EVER again!*
+
+    *Second update*
+
+!!! info "Further reading and information"
+    [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+
+    [commitlint/@commitlint/config-conventional at master · conventional-changelog/commitlint · GitHub](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
+
+    [A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+
+    [How to Write a Git Commit Message (cbea.ms)](https://cbea.ms/git-commit/)
+
+    [How to Write Good Commit Messages: A Practical Git Guide (freecodecamp.org)](https://www.freecodecamp.org/news/writing-good-commit-messages-a-practical-guide/)
+
+    [Writing Meaningful Commit Messages --- Beanstalk (beanstalkapp.com)](https://blog.beanstalkapp.com/post/134929320564/detailed-commit-messages-are-an-essential-part-of)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ extra:
     provider: simple
 markdown_extensions:
   - admonition
+  - footnotes
   - pymdownx.details
   - pymdownx.superfences:
       custom_fences:


### PR DESCRIPTION
## Description
Initial version of Software Development Handbook

- Converted from original Word (`.docx`) files.
- Conversion utilised Pandoc to convert each Word file to raw Markdown
- Claude Code used to convert the raw Markdown to a format compatible with mkdocs
- Claude undertook various cleanup tasks (merging introduction sections, fixing markdown lint, fixing broken links etc.)

## Related
* See https://github.com/collisdigital/ai-skills/blob/main/word-to-mkdocs-instructions.md for the original instructions used to bootstrap this conversion.

## Motivation and Context
* We want to make our software development handbook and guides accessible and public as it contains valuable content.

## How to review
* You can see a preview of the site based on this branch here: https://collisdigital.github.io/software-development-standards/
* Check for any glaring major issues, there are a lot of files here so perhaps sample some pages rather than review everything here.
* The recommendation is to merge this PR as the initial bootstrap and then iteratitvely improve through further PRs/edits.
* Any stylistic changes can be made separate to this PR (e.g. changing the good practice/tips etc. format/icons/layouts)
* I suggest raising [Issues](https://github.com/Work-In-Progress-For-Health/software-development-standards/issues) so any updates can be triaged, tracked and resolved separate from this PR due to the size of this one.

---

Co-authored-by: Claude <noreply@anthropic.com>