### PR TITLE
Added writing standards and RFC 2119 guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,6 +24,37 @@ This handbook provides comprehensive guidance covering:
 - Security practices (OWASP Top 10)
 - Accessibility standards
 
+## Documentation Writing Standards
+
+These guidelines are derived from DHCW organisational writing standards and adapted for technical documentation within this repository.
+
+When generating or updating documentation in this repository:
+
+- Write clearly and concisely for a technical audience
+- Use short, well-structured sentences
+- Use headings, bullet points, and lists to improve readability
+- Make content easy to scan and navigate
+- Front-load key information at the start of sections
+- Focus on helping the reader understand concepts or complete tasks
+- Avoid unnecessary jargon, but use precise technical language where appropriate
+- Explain acronyms on first use
+- Use a professional and direct tone (avoid overly informal or conversational language)
+- Prefer active voice where it improves clarity
+
+
+## Standards Language (RFC 2119)
+
+This handbook uses RFC 2119 terminology to define requirement levels.
+
+When writing standards or guidance:
+
+- Use terms such as MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL as defined in RFC 2119
+- Only use these terms where normative language is intended
+- Do not use these terms casually or interchangeably with everyday language
+- Ensure consistency with existing handbook content
+
+Reference: https://www.ietf.org/rfc/rfc2119.txt
+
 ## Technology Stack
 
 | Component | Technology | Purpose |


### PR DESCRIPTION
## Description

Adds documentation writing guidance, derived from DHCW organisational standards and explicitly aligns Copilot instructions with RFC 2119 terminology already used throughout the handbook.

## Related

N/A

## Motivation and Context

- The handbook consistently uses RFC 2119 terms (MUST, SHOULD, etc.) to define requirement levels
- These conventions were not explicitly captured in the Copilot instructions
- This change ensures AI-assisted contributions follows current standards
- Introduces a concise, **tailored subset of DHCW organisational writing guidance**, adapted specifically for technical documentation 
- Improves consistency, clarity, and professionalism across documentation

## How to review

- Verify the new **Documentation Writing Standards** section aligns with existing handbook tone and structure
- Confirm the **RFC 2119 guidance** accurately reflects how normative language is used across the handbook
- Check placement (after "Documentation Scope") maintains logical flow and does not disrupt existing structure
- Ensure the changes are concise and do not introduce new standards beyond what already exists
- Check markdown follows linting rules