### PR TITLE
Remove Developers from team naming examples

### DIFF
--- a/doc/azure-devops-handbook/adding-users-and-teams.md
+++ b/doc/azure-devops-handbook/adding-users-and-teams.md
@@ -27,8 +27,6 @@ sprints, and dashboards.
 
     **Helios Appointments Team**: Immunisations appointment scheduler microservice.
 
-    **Developers**
-
 !!! info "Further reading and information"
     [Create or add a team - Azure DevOps \| Microsoft Learn](https://learn.microsoft.com/en-gb/azure/devops/organizations/settings/add-teams?view=azure-devops&tabs=preview-page)
 


### PR DESCRIPTION
## Summary

- Remove the standalone `Developers` entry from the Azure DevOps team naming examples.
- Keep the existing guidance that generic team names should be avoided.

Closes #29

## Checks

- `npx markdownlint-cli2 "doc/**/*.md" --config .markdownlint-cli2.jsonc`
- `npx cspell-cli "doc/**/*.md"`
- `python3 scripts/check-links.py doc/`
- `$HOME/.local/bin/uv run zensical build --clean`
