### PR TITLE
fix: replace theme name with variant in zensical.toml

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -230,7 +230,7 @@ custom_fences = [
 
 # Theme configuration
 [project.theme]
-name = "modern"
+variant = "modern"
 custom_dir = "doc/overrides"
 logo = "assets/logo.png"
 favicon = "assets/favicon.ico"


### PR DESCRIPTION
Fixes broken GitHub Pages deployment caused by changes in newer Zensical versions.

## Description
Updates zensical.toml to use variant instead of name for theme configuration.

## Related
N/A

## Motivation and Context
GitHub Pages builds began failing. It 's likley this is because newer versions of Zensical no longer support the **_name_** configuration option for themes. This change updates the configuration to use the supported variant option, restoring compatibility with the version used during GitHub Pages builds.

## How to review

1. Review the changes to zensical.toml.
2. Confirm that theme configuration now uses variant instead of name.
3. Verify that the site builds successfully via GitHub Pages or a local build using the current Zensical version.