### PR TITLE
feat: add issue form and improve contribution guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-suggest-change.yml
+++ b/.github/ISSUE_TEMPLATE/1-suggest-change.yml
@@ -1,0 +1,34 @@
+name: 💡 Suggest a change
+description: Report something wrong, suggest improvements or ideas for new guidance.
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before you file an issue:**
+
+        - Read the [Contributing guide](https://github.com/GIGCymru/dhcw-software-engineering-handbook/blob/main/CONTRIBUTING.md)
+        - Follow our [Code of Conduct](https://github.com/GIGCymru/dhcw-software-engineering-handbook/blob/main/CODE_OF_CONDUCT.md)
+        - Check for an existing [issue](https://github.com/GIGCymru/dhcw-software-engineering-handbook/issues)
+
+        Thanks for helping improve the handbook 🙌
+  - type: input
+    id: location
+    attributes:
+      label: Relevant page or section (optional)
+      placeholder: e.g. Using Source Control
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the change
+      description: What is wrong, unclear, or missing? Include any relevant details.
+      placeholder: e.g. There is no guidance on forking a repository or creating a branch before making changes.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this change useful? (optional)
+      description: Optional — who benefits and how?
+      placeholder: e.g. This would help new contributors who are unsure how to start working on a changes.

--- a/.github/ISSUE_TEMPLATE/1-suggest-change.yml
+++ b/.github/ISSUE_TEMPLATE/1-suggest-change.yml
@@ -31,4 +31,5 @@ body:
     attributes:
       label: Why is this change useful? (optional)
       description: Optional — who benefits and how?
-      placeholder: e.g. This would help new contributors who are unsure how to start working on a changes.
+      placeholder: e.g. This would help new contributors who are unsure how to start working on a change.
+      

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: 📘 Contributing Guide
+    url: https://github.com/GIGCymru/dhcw-software-engineering-handbook/blob/main/CONTRIBUTING.md
+    about: How to suggest changes or contribute to the handbook.
+
+  - name: 📜 Code of Conduct
+    url: https://github.com/GIGCymru/dhcw-software-engineering-handbook/blob/main/CODE_OF_CONDUCT.md
+    about: Expected behaviour when taking part in this project.
+
+issue_templates:
+  - name: 💡 Suggest a change
+    description: Fix something wrong, improve content, or add new guidance.
+    filename: suggest-a-change.yml

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,8 +8,4 @@ contact_links:
   - name: 📜 Code of Conduct
     url: https://github.com/GIGCymru/dhcw-software-engineering-handbook/blob/main/CODE_OF_CONDUCT.md
     about: Expected behaviour when taking part in this project.
-
-issue_templates:
-  - name: 💡 Suggest a change
-    description: Fix something wrong, improve content, or add new guidance.
-    filename: suggest-a-change.yml
+    

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,174 @@
-# Contributing
+# Contributing to the Digital Health and Care Wales (DHCW) Software Engineering Handbook
 
-We welcome people contributing. We welcome feedback, suggestions, ideas, and help.
+Thanks for taking the time to improve the handbook.
 
-To contact a particular repository's team, a good way is to create a GitHub issue.
+This repository is a public-facing handbook for DHCW developers and other technical staff. We welcome improvements from DHCW colleagues, partners, and external contributors.
 
-To contribute code to a particular repository, a good way is to create a GitHub pull request.
+## Before you start
 
-To email a particular person, contact information will typically be provided in each repository's top level README file.
+Please read:
 
-If you need more help, such as a direct contact person, then please contact Joel Henderson at <joel.henderson@wales.nhs.uk>.
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [README](README.md)
+
+If you are unsure whether a change belongs here, open an issue and a maintainer will help.
+
+## What belongs in this repository
+
+This handbook is for practical software engineering guidance that is suitable for open publication.
+
+Please contribute:
+
+- fixes to existing pages
+- clearer wording and better examples
+- missing guidance that can be shared publicly
+- links to useful public references
+- accessibility improvements
+- typo fixes, formatting fixes, and broken links
+
+Please do not add:
+
+- confidential or internal-only DHCW information
+- content that belongs in the private DHCW Cloud Engineering Reference
+- credentials, secrets, personal data, or sensitive operational details
+
+For cloud architecture, platform design, and infrastructure delivery guidance, the private DHCW Cloud Engineering Reference is the authoritative source. If a suggestion overlaps with that material, please keep the public handbook high level and public-safe.
+
+## How to contribute
+
+We use GitHub Issues and Pull Requests for changes.
+
+### 1. Open an issue
+
+For most changes, start by opening the issue form in this repository.
+
+There is one issue form:
+
+- **Suggest a change** — use this for ideas, questions, proposed updates, or anything that is not yet ready for a pull request
+
+Use the issue to explain:
+
+- what you want to change
+- why the change is needed
+- which page or section it affects
+- any relevant links or context
+
+### 2. Make your change
+
+Fork the repository, create a feature branch, then edit the relevant file.
+
+Keep changes small and focused where possible.
+
+### 3. Check it locally
+
+The handbook repository README explains how to run the site locally.
+
+Please use that local setup to check:
+
+- the site builds successfully
+- your page renders as expected
+- internal links and anchors still work
+- that formatting looks right
+- that headings and navigation make sense
+- any changed examples are accurate
+
+### 4. Open a pull request
+
+When your change is ready, open a pull request and link the related issue if there is one.
+
+In your pull request description, please include:
+
+- a short summary of the change
+- why it is needed
+- any screenshots or preview links, if useful
+- anything reviewers should know
+
+## Pull request expectations
+
+Please make sure your pull request:
+
+- is easy to review
+- only contains the changes needed for that task
+- has clear commit messages
+- follows the style of the surrounding content
+- does not introduce confidential content
+
+Maintainers may ask for changes before merging. This is normal and helps keep the handbook consistent and safe to publish.
+
+## Documentation standards
+
+Please write in plain English.
+
+Aim for content that is:
+
+- clear and practical
+- accurate and up to date
+- easy to scan
+- consistent with the rest of the handbook
+- suitable for a public audience
+
+Please prefer:
+
+- short paragraphs
+- clear headings
+- examples where they help
+- links to authoritative sources
+
+Please avoid:
+
+- jargon where simple wording will do
+- long, repetitive explanations
+- personal opinions presented as policy
+- internal process details that are not relevant to readers
+
+## Accessibility and inclusive language
+
+Please make content accessible to everyone.
+
+That means:
+
+- use descriptive headings and link text
+- avoid unnecessary acronyms
+- write inclusive, respectful language
+- use plain language where possible
+- avoid colour-only instructions
+- check that examples and images are understandable without extra context
+
+## Maintainers
+
+Maintainers are responsible for:
+
+- reviewing contributions
+- keeping the handbook aligned with DHCW standards
+- checking that public content is safe to publish
+- coordinating updates where changes affect multiple pages
+
+If you are a DHCW colleague and want to propose a broader update, please use the issue form first so maintainers can help shape the change.
+
+## Review process
+
+Maintainers will review pull requests for:
+
+- correctness
+- clarity
+- consistency
+- accessibility
+- public-safety and confidentiality
+
+A pull request may be merged once it has the necessary approvals and checks.
+
+## Code of conduct
+
+This repository follows the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Please be respectful, constructive, and professional in all discussions.
+
+## Security issues
+
+Do not report security vulnerabilities in a public issue or pull request.
+
+If you find a security issue, do not report it in a public issue or pull request. Please contact the DHCW security team directly.
+
+## Thank you
+
+Every improvement helps make the handbook clearer and more useful for everyone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,10 @@ There is one issue form:
 
 - **Suggest a change** — use this for ideas, questions, proposed updates, or anything that is not yet ready for a pull request
 
+For very small fixes — a typo, a broken link, or a formatting error — you can skip the issue and go straight to a pull request.
+
+If you're not sure where to start, look for issues labelled [good first issue](https://github.com/GIGCymru/dhcw-software-engineering-handbook/labels/good%20first%20issue).
+
 Use the issue to explain:
 
 - what you want to change
@@ -55,9 +59,18 @@ Use the issue to explain:
 
 ### 2. Make your change
 
-Fork the repository, create a feature branch, then edit the relevant file.
-
 Keep changes small and focused where possible.
+
+**If you're a DHCW colleague (GIGCymru org member),** clone the repository directly and create a feature branch:
+
+```
+git clone https://github.com/GIGCymru/dhcw-software-engineering-handbook.git
+
+git checkout -b feature/your-change-description
+```
+If you don't yet have access to the GIGCymru GitHub organisation, contact the Head of Software Engineering to request it.
+
+**If you're an external contributor,** fork the repository on GitHub first, then clone your fork and create a feature branch.
 
 ### 3. Check it locally
 
@@ -121,6 +134,12 @@ Please avoid:
 - personal opinions presented as policy
 - internal process details that are not relevant to readers
 
+## Use of AI tools
+
+We welcome contributions where AI tools have helped with drafting or editing content.
+
+You're responsible for reviewing and validating everything in your pull request. Don't submit AI-generated content without reading and checking it yourself first.
+
 ## Accessibility and inclusive language
 
 Please make content accessible to everyone.
@@ -157,17 +176,9 @@ Maintainers will review pull requests for:
 
 A pull request may be merged once it has the necessary approvals and checks.
 
-## Code of conduct
-
-This repository follows the [Code of Conduct](CODE_OF_CONDUCT.md).
-
-Please be respectful, constructive, and professional in all discussions.
-
 ## Security issues
 
-Do not report security vulnerabilities in a public issue or pull request.
-
-If you find a security issue, do not report it in a public issue or pull request. Please contact the DHCW security team directly.
+Do not report security vulnerabilities in a public issue or pull request. Contact the DHCW security team directly.
 
 ## Thank you
 

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ Our documentation is built using [Zensical](https://zensical.org/), a modern sta
 
 ## Contributing
 
-1. Choose your preferred development environment from above
-2. Create a new branch for your changes
-3. Make your changes
-4. Test your changes locally
-5. Submit a Pull Request
+We welcome suggestions and improvements from DHCW colleagues, partners and the wider community.
+
+To suggest a change, [open an issue](https://github.com/GIGCymru/dhcw-software-engineering-handbook/issues/new/choose) using the issue form in this repository.
+
+To contribute directly, read the [Contributing Guide](CONTRIBUTING.md) before you start. It covers the full workflow, including how DHCW staff can get repository access.
 
 ## Licence
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -18,4 +18,13 @@ It's there to help you make good decisions, avoid mistakes, and deliver software
 
 ## Contributing
 
-Thanks for your interest in contributing! We're still working out how we’d like to manage contributions. In the meantime, we’d love to hear your ideas—please feel free to open an issue with any suggestions. We'll share proper contribution guidelines soon.
+We welcome suggestions and improvements from colleagues, partners, and the wider community.
+
+To suggest a change, please open an issue using the issue form on this repository.
+
+Please read:
+
+- [Contributing Guide](https://github.com/GIGCymru/dhcw-software-engineering-handbook/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/GIGCymru/dhcw-software-engineering-handbook/blob/main/CODE_OF_CONDUCT.md)
+
+If you're unsure whether your idea is ready, open an issue anyway and a maintainer will help shape it.


### PR DESCRIPTION
# Add contribution workflow and issue form

## Description

This PR improves the contribution experience for both DHCW colleagues and external contributors.

Changes include:

* Add a **Submit a change** issue form under `.github/ISSUE_TEMPLATE/`
* Update `CONTRIBUTING.md` with clearer contributor guidance and expectations
* Update `docs/index.md` to explain how users can suggest changes and contribute to the handbook

## Related

N/A

## Motivation and Context

The handbook is intended to be a living resource that evolves through feedback and contributions from DHCW staff, partners, and the wider community.

Previously, guidance on how to contribute was limited and there was no structured route for users to propose changes.

This PR:

* Creates a single, simple contribution path using an issue form
* Makes it easier for colleagues to suggest improvements
* Provides clearer expectations for contributors and reviewers
* Aligns the repository more closely with GitHub documentation best practices
* Encourages community participation while maintaining appropriate governance for a public DHCW repository

## How to review

1. Review the new issue form and confirm the questions capture the information maintainers need.
2. Review `CONTRIBUTING.md` and confirm the workflow reflects how contributions should be made.
3. Review the changes to `index.md` and ensure contributors are directed to the correct locations.
4. Verify URL updates and confirm links resolve correctly.
5. Check that the contribution guidance remains appropriate for a public repository while supporting internal DHCW adoption.