### PR TITLE
docs: add SECURITY.md and document private security reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ A pull request may be merged once it has the necessary approvals and checks.
 
 ## Security issues
 
-Do not report security vulnerabilities in a public issue or pull request. Contact the DHCW security team directly.
+For security vulnerabilities, please see [SECURITY.md](./SECURITY.md)
 
 ## Thank you
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ A pull request may be merged once it has the necessary approvals and checks.
 
 ## Security issues
 
-For security vulnerabilities, please see [SECURITY.md](./SECURITY.md)
+For security vulnerabilities, please see [SECURITY.md](SECURITY.md).
 
 ## Thank you
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ please report it by email to:
 **dhcw-engineering.handbook-team@wales.nhs.uk**
 
 Include the affected page or URL if you can, and a brief description of
-the concern. We will respond as soon as we can.
+the concern. We will acknowledge your report within 5 working days.
 
 For general content errors, broken links, or editorial feedback, please open a
 [GitHub Issue](https://github.com/GIGCymru/dhcw-software-engineering-handbook/issues)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,9 @@ published by Digital Health and Care Wales (DHCW) / GIG Cymru NHS Wales.
 
 ## Reporting a Security Concern
 
-**Please do not raise security concerns as public issues or pull requests.**
+**Please do not raise security concerns in public issues or pull requests.**
 
-If you spot something that shouldn't be here — such as personal or
+If you spot something that should not be publicly available — for example, personal or
 patient-identifiable information, internal system details, or credentials —
 please report it by email to:
 
@@ -22,4 +22,4 @@ instead.
 
 ---
 
-*DHCW Software Engineering — last reviewed July 2026*
+*DHCW Software Engineering Handbook — last reviewed July 2026*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+This repository contains the DHCW Software Engineering Handbook — guidance
+published by Digital Health and Care Wales (DHCW) / GIG Cymru NHS Wales.
+
+## Reporting a Security Concern
+
+**Please do not raise security concerns as public issues or pull requests.**
+
+If you spot something that shouldn't be here — such as personal or
+patient-identifiable information, internal system details, or credentials —
+please report it by email to:
+
+**dhcw-engineering.handbook-team@wales.nhs.uk**
+
+Include the affected page or URL if you can, and a brief description of
+the concern. We will respond as soon as we can.
+
+For general content errors, broken links, or editorial feedback, please open a
+[GitHub Issue](https://github.com/GIGCymru/dhcw-software-engineering-handbook/issues)
+instead.
+
+---
+
+*DHCW Software Engineering — last reviewed July 2026*


### PR DESCRIPTION
- add SECURITY.md with vulnerability reporting guidance
- update CONTRIBUTING.md with link to SECURITY.md

## Description
Adds a security policy and updates contributing guidelines to direct users to the security policy for reporting vulnerabilities.

## Related
Closes #33 

## Motivation and Context
We need a clear, private process for reporting security vulnerabilities so they are not disclosed publicly.

## How to review
- Open CONTRIBUTING.md and confirm the Security section links to SECURITY.md
- Open SECURITY.md and confirm reporting instructions are clear and include contact method
- Ensure no sensitive or unintended information is exposed publicly