### PR TITLE
fix(deps): pin picomatch to 4.0.4 for cspell-glob via override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2314,9 +2314,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "markdownlint-cli2": "^0.23.1"
   },
   "overrides": {
-    "cspell-glob": {
+    "cspell-glob@^9.0.0": {
       "picomatch": "4.0.4"
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,5 +2,10 @@
   "devDependencies": {
     "cspell-cli": "^9.6.0",
     "markdownlint-cli2": "^0.23.1"
+  },
+  "overrides": {
+    "cspell-glob": {
+      "picomatch": "4.0.4"
+    }
   }
 }


### PR DESCRIPTION
## Description
Fixes a known vulnerability in `picomatch` (currently resolving to `4.0.3`, which is used internally by `cspell-glob`/`cspell`). Dependabot's automated PR for this (#24) could not resolve it, because the lockfile also contains a completely separate, unrelated `picomatch@2.3.1` install (used only by `micromatch`, deep inside `markdownlint-cli2`'s dependency chain, which does not yet support anything beyond picomatch 2.x). Dependabot's resolver tried to satisfy both at once and proposed downgrading `markdownlint-cli2` to `0.0.4` as the only path forward — not viable.

This PR adds a scoped `overrides` entry in `package.json` so that **only** `cspell-glob`'s picomatch resolves to the fixed `4.0.4`, leaving the unrelated `micromatch` → `picomatch@2.3.1` copy completely untouched.

## Related
- Dependabot alert: https://github.com/GIGCymru/dhcw-software-engineering-handbook/security/dependabot/5
- Supersedes (closed, unresolved) Dependabot PR: #24

## Motivation and Context
`picomatch@4.0.3` (installed via `cspell-glob`) falls within the affected vulnerable range (`>=4.0.0 <4.0.4`). Dependabot could not fix this automatically because of an unrelated, harmless picomatch install elsewhere in the tree (`micromatch@4.0.8` → `picomatch@^2.3.1`, used by `markdownlint-cli2`). Since npm supports multiple independent copies of the same package at different versions, this PR manually applies a narrowly-scoped fix rather than waiting on `micromatch` to add support for picomatch 3.x/4.x (which it does not currently support, even at its latest release).

## How to review
- Confirm `package-lock.json` only shows a version change for the top-level `node_modules/picomatch` entry (`4.0.3 → 4.0.4`) — no changes to `markdownlint-cli2`, `micromatch`, or the nested `node_modules/micromatch/node_modules/picomatch` entry (should remain `2.3.1`).
- Confirm `package.json` only adds the new `overrides` block — no other dependency changes.
- Run `just run` and confirm the site builds and serves without errors.
- Run the spellcheck step (`cspell`) to confirm it still functions correctly with the updated picomatch.